### PR TITLE
Add PHP 7.4 to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 services:
   - mysql


### PR DESCRIPTION
This PR adds PHP 7.4 support to TravisCI tests.