### PR TITLE
[ENHANCEMENT] - Always throw exceptions

### DIFF
--- a/lib/PicoDb/StatementHandler.php
+++ b/lib/PicoDb/StatementHandler.php
@@ -344,10 +344,6 @@ class StatementHandler
         $this->db->cancelTransaction();
         $this->db->setLogMessage($e->getMessage());
 
-        if ($this->db->getDriver()->isDuplicateKeyError($e->getCode())) {
-            return false;
-        }
-
         throw new SQLException('SQL Error: '.$e->getMessage());
     }
 }

--- a/tests/MysqlDatabaseTest.php
+++ b/tests/MysqlDatabaseTest.php
@@ -51,12 +51,12 @@ class MysqlDatabaseTest extends \PHPUnit\Framework\TestCase
 
     public function testDuplicateKey()
     {
+        $this->expectException(\PicoDb\SQLException::class);
+
         $this->db->getConnection()->exec('CREATE TABLE foobar (something CHAR(1) UNIQUE) ENGINE=InnoDB');
 
         $this->assertNotFalse($this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a')));
-        $this->assertFalse($this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a')));
-
-        $this->assertEquals(1, $this->db->execute('SELECT COUNT(*) FROM foobar WHERE something=?', array('a'))->fetchColumn());
+        $this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
     }
 
     public function testThatTransactionReturnsAValue()
@@ -89,11 +89,13 @@ class MysqlDatabaseTest extends \PHPUnit\Framework\TestCase
 
     public function testThatTransactionReturnsFalseWhithDuplicateKey()
     {
-        $this->assertFalse($this->db->transaction(function (Database $db) {
+        $this->expectException(\PicoDb\SQLException::class);
+
+        $this->db->transaction(function (Database $db) {
             $db->getConnection()->exec('CREATE TABLE foobar (something CHAR(1) UNIQUE) ENGINE=InnoDB');
             $r1 = $db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
             $r2 = $db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
             return $r1 && $r2;
-        }));
+        });
     }
 }

--- a/tests/PostgresDatabaseTest.php
+++ b/tests/PostgresDatabaseTest.php
@@ -50,12 +50,12 @@ class PostgresDatabaseTest extends \PHPUnit\Framework\TestCase
 
     public function testDuplicateKey()
     {
+        $this->expectException(\PicoDb\SQLException::class);
+
         $this->db->getConnection()->exec('CREATE TABLE foobar (something TEXT UNIQUE)');
 
         $this->assertNotFalse($this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a')));
-        $this->assertFalse($this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a')));
-
-        $this->assertEquals(1, $this->db->execute('SELECT COUNT(*) FROM foobar WHERE something=?', array('a'))->fetchColumn());
+        $this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
     }
 
     public function testThatTransactionReturnsAValue()
@@ -88,11 +88,13 @@ class PostgresDatabaseTest extends \PHPUnit\Framework\TestCase
 
     public function testThatTransactionReturnsFalseWhithDuplicateKey()
     {
-        $this->assertFalse($this->db->transaction(function (Database $db) {
+        $this->expectException(\PicoDb\SQLException::class);
+
+        $this->db->transaction(function (Database $db) {
             $db->getConnection()->exec('CREATE TABLE foobar (something TEXT UNIQUE)');
             $r1 = $db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
             $r2 = $db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
             return $r1 && $r2;
-        }));
+        });
     }
 }

--- a/tests/SqliteDatabaseTest.php
+++ b/tests/SqliteDatabaseTest.php
@@ -48,12 +48,12 @@ class SqliteDatabaseTest extends \PHPUnit\Framework\TestCase
 
     public function testDuplicateKey()
     {
+        $this->expectException(\PicoDb\SQLException::class);
+
         $this->db->getConnection()->exec('CREATE TABLE foobar (something TEXT UNIQUE)');
 
         $this->assertNotFalse($this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a')));
-        $this->assertFalse($this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a')));
-
-        $this->assertEquals(1, $this->db->execute('SELECT COUNT(*) FROM foobar WHERE something=?', array('a'))->fetchColumn());
+        $this->db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
     }
 
     public function testThatTransactionReturnsAValue()
@@ -86,12 +86,14 @@ class SqliteDatabaseTest extends \PHPUnit\Framework\TestCase
 
     public function testThatTransactionReturnsFalseWhithDuplicateKey()
     {
-        $this->assertFalse($this->db->transaction(function (Database $db) {
+        $this->expectException(\PicoDb\SQLException::class);
+
+        $this->db->transaction(function (Database $db) {
             $db->getConnection()->exec('CREATE TABLE foobar (something TEXT UNIQUE)');
             $r1 = $db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
             $r2 = $db->execute('INSERT INTO foobar (something) VALUES (?)', array('a'));
             return $r1 && $r2;
-        }));
+        });
     }
 
     public function testGetInstance()


### PR DESCRIPTION
This PR updates the `StatementHandler::handleSqlError()` method to throw exceptions for duplicate key errors, bringing consistency to the way errors are handled. Prior to this change, inserts would fail silently when a duplicate key error occurred but would throw an exception for any other form of error (e.g. using an invalid column name), making it easy to miss issues within a transaction.

**Note:** This should be considered an API-incompatible change since it alters the method's signature / contract. It will therefore be released as a new major version.