### PR TITLE
Add the ability to count a specific column, and to choose to if you want to count distinct entries only

### DIFF
--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -401,12 +401,20 @@ class Table
      * Count
      *
      * @access public
+     * @param string $column
+     * @param bool $distinct
      * @return integer
      */
-    public function count()
+    public function count(string $column = '*', bool $distinct = false)
     {
+        $column = $this->db->escapeIdentifier($column);
+
+        if ($distinct) {
+            $column = 'DISTINCT ' . $column;
+        }
+
         $sql = sprintf(
-            'SELECT COUNT(*) FROM %s '.implode(' ', $this->joins).$this->conditionBuilder->build().$this->sqlOrder.$this->sqlLimit.$this->sqlOffset,
+            'SELECT COUNT(' . $column . ') FROM %s '.implode(' ', $this->joins).$this->conditionBuilder->build().$this->sqlOrder.$this->sqlLimit.$this->sqlOffset,
             $this->db->escapeIdentifier($this->name)
         );
 
@@ -420,10 +428,10 @@ class Table
      * Sum
      *
      * @access public
-     * @param  string   $column
+     * @param string $column
      * @return float
      */
-    public function sum($column)
+    public function sum(string $column)
     {
         $sql = sprintf(
             'SELECT SUM(%s) FROM %s '.implode(' ', $this->joins).$this->conditionBuilder->build().$this->sqlOrder.$this->sqlLimit.$this->sqlOffset,

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -407,7 +407,9 @@ class Table
      */
     public function count(string $column = '*', bool $distinct = false)
     {
-        $column = $this->db->escapeIdentifier($column);
+        if ($column != '*') {
+            $column = $this->db->escapeIdentifier($column);
+        }
 
         if ($distinct) {
             $column = 'DISTINCT ' . $column;

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -215,6 +215,26 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(), $table->getConditionBuilder()->getValues());
     }
 
+    public function testCount()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (a INTEGER, b INTEGER )'));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 1)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
+        
+        $query = $this->db->table('foobar');
+        $this->assertEquals(5, $query->count());
+        $this->assertEquals(3, $query->count('a', true));
+        $this->assertEquals(4, $query->count('b', true));
+
+        $query->eq('b', 3);
+        $this->assertEquals(2, $query->count());
+        $this->assertEquals(2, $query->count('a', true));
+        $this->assertEquals(1, $query->count('b', true));
+    }
+
     public function testCustomCondition()
     {
         $table = $this->db->table('test');

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -214,6 +214,25 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(), $table->getConditionBuilder()->getValues());
     }
 
+    public function testCount()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (a INTEGER, b INTEGER )'));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 1)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
+        $query = $this->db->table('foobar');
+        $this->assertEquals(5, $query->count());
+        $this->assertEquals(3, $query->count('a', true));
+        $this->assertEquals(4, $query->count('b', true));
+
+        $query->eq('b', 3);
+        $this->assertEquals(2, $query->count());
+        $this->assertEquals(2, $query->count('a', true));
+        $this->assertEquals(1, $query->count('b', true));
+    }
+
     public function testCustomCondition()
     {
         $table = $this->db->table('test');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -261,6 +261,25 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(), $table->getConditionBuilder()->getValues());
     }
 
+    public function testCount()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (a INTEGER)'));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 1)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
+        $query = $this->db->table('foobar');
+        $this->assertEquals(5, $query->count());
+        $this->assertEquals(3, $query->count('a', true));
+        $this->assertEquals(4, $query->count('b', true));
+
+        $query->eq('b', 3);
+        $this->assertEquals(2, $query->count());
+        $this->assertEquals(2, $query->count('a', true));
+        $this->assertEquals(1, $query->count('b', true));
+    }
+
     public function testCustomCondition()
     {
         $table = $this->db->table('test');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -263,7 +263,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
 
     public function testCount()
     {
-        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (a INTEGER)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (a INTEGER, b INTEGER )'));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 1)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -268,7 +268,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 1)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
-        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
         $this->assertEquals(3, $query->count('a', true));


### PR DESCRIPTION
This PR allows a user to specify which column to count in the `count` function, and whether you wish to count distinct entries only. 

This helps address an issue where you're building a query, and potentially only selecting a particular column, especially in scenarios you've joined onto another table. 

For example, in this case 3 user IDs are provided, but only 2 of them have a password. However, each of them have multiple posts attributed to them. (Let's just say all authors have 3 posts):
```
$query = $this->db->table('users u');
$query
    ->in('u.id', [1,2,3])
    ->notNull('u.password')
    ->join(
        'posts p',
        'author.id',
        'id',
        'u',
        'p')
    ->columns(['DISTINCT u.email_address']);
$count = $query->count();
$results = $query->findAll();
$resultsCount = count($results);
echo "Results Count: $resultsCount - PICO Count: $count";

Right now this would output `Results Count: 2 - PICO Count: 6` 

If we were able to do `$count = $query->('u.email_address', true);` however this would then give the same count for results and the `count` function. 