### PR TITLE
Add Values to Builders When Using Subqueries

### DIFF
--- a/lib/PicoDb/Builder/BaseConditionBuilder.php
+++ b/lib/PicoDb/Builder/BaseConditionBuilder.php
@@ -79,7 +79,7 @@ class BaseConditionBuilder
      * Adds condition values
      *
      * @access public
-     * @param  array
+     * @param  array $values
      */
     public function addValues($values)
     {

--- a/lib/PicoDb/Builder/BaseConditionBuilder.php
+++ b/lib/PicoDb/Builder/BaseConditionBuilder.php
@@ -76,6 +76,17 @@ class BaseConditionBuilder
     }
 
     /**
+     * Adds condition values
+     *
+     * @access public
+     * @param  array
+     */
+    public function addValues($values)
+    {
+        $this->values = array_merge($this->values, $values);
+    }
+
+    /**
      * Returns true if there is some conditions
      *
      * @access public

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -784,6 +784,9 @@ class Table
         } else {
             call_user_func_array(array($this->conditionBuilder, $name), $arguments);
         }
+        if (count($arguments) == 2 && end($arguments) instanceof Table) {
+            $this->addSubqueryValues(end($arguments));
+        }
         return $this;
     }
 
@@ -794,5 +797,20 @@ class Table
      {
          $this->conditionBuilder = clone $this->conditionBuilder;
          $this->aggregatedConditionBuilder = clone $this->aggregatedConditionBuilder;
+     }
+
+     /**
+      * Adds values to builder when subquery is added to the other
+      *
+      * @access private
+      * @param  Table $subquery
+      */
+     private function addSubqueryValues(Table $subquery)
+     {
+         if ($this->conditionalBuilder === 'HAVING') {
+             $this->conditionBuilder->addValues($subquery->getConditionBuilder()->getValues());
+         } else {
+             $this->aggregatedConditionBuilder->addValues($subquery->getAggregatedConditionBuilder()->getValues());
+         }
      }
 }

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -259,6 +259,17 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 
+    public function testHavingSubquery()
+    {
+        $table = $this->db->table('test')->notNull('a')->beginOr()->eq('b', 2)->gte('c', 5)->closeOr();
+        $subquery = $this->db->table('test')->columns('a')->groupBy('a')->having()->gte('SUM( d )', 10);
+        $table->inSubquery('a', $subquery);
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` IS NOT NULL AND (`b` = ? OR `c` >= ?) AND `a` IN (SELECT `a` FROM `test`   GROUP BY `a`  HAVING SUM( d ) >= ?)', $table->buildSelectQuery());
+        $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(10), $table->getAggregatedConditionBuilder()->getValues());
+    }
+
     public function testPersist()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE foobar_persist (id INT NOT NULL AUTO_INCREMENT, a VARCHAR(10), PRIMARY KEY(id))'));

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -304,6 +304,17 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 
+    public function testHavingSubquery()
+    {
+        $table = $this->db->table('test')->notNull('a')->beginOr()->eq('b', 2)->gte('c', 5)->closeOr();
+        $subquery = $this->db->table('test')->columns('a')->groupBy('a')->having()->gte('SUM( d )', 10);
+        $table->inSubquery('a', $subquery);
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" IS NOT NULL AND ("b" = ? OR "c" >= ?) AND "a" IN (SELECT "a" FROM "test"   GROUP BY "a"  HAVING SUM( d ) >= ?)', $table->buildSelectQuery());
+        $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(10), $table->getAggregatedConditionBuilder()->getValues());
+    }
+
     public function testMultipleOrConditions()
     {
         $table = $this->db->table('test');


### PR DESCRIPTION
This PR resolves issue #13 

When adding a subquery to a conditional builder aggregate values are now also propagated to the parent query.