### PR TITLE
Add notLike, between and not between. 

### DIFF
--- a/lib/PicoDb/Builder/BaseConditionBuilder.php
+++ b/lib/PicoDb/Builder/BaseConditionBuilder.php
@@ -280,6 +280,18 @@ class BaseConditionBuilder
     }
 
     /**
+     * NOT LIKE condition
+     *
+     * @param $column
+     * @param $value
+     */
+    public function notLike($column, $value)
+    {
+        $this->addCondition($this->db->escapeIdentifier($column).' NOT LIKE ?');
+        $this->values[] = $value;
+    }
+
+    /**
      * Greater than condition
      *
      * @access public

--- a/lib/PicoDb/Builder/BaseConditionBuilder.php
+++ b/lib/PicoDb/Builder/BaseConditionBuilder.php
@@ -396,6 +396,34 @@ class BaseConditionBuilder
     }
 
     /**
+     * BETWEEN operator
+     *
+     * @param $column
+     * @param $lowValue
+     * @param $highValue
+     */
+    public function between($column, $lowValue, $highValue)
+    {
+        $this->addCondition($this->db->escapeIdentifier($column).' BETWEEN ? AND ?');
+        $this->values[] = $lowValue;
+        $this->values[] = $highValue;
+    }
+
+    /**
+     * NOT BETWEEN operator
+     *
+     * @param $column
+     * @param $lowValue
+     * @param $highValue
+     */
+    public function notBetween($column, $lowValue, $highValue)
+    {
+        $this->addCondition($this->db->escapeIdentifier($column).' NOT BETWEEN ? AND ?');
+        $this->values[] = $lowValue;
+        $this->values[] = $highValue;
+    }
+
+    /**
      * IS NULL condition
      *
      * @access public

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -417,7 +417,7 @@ class Table
     public function count(string $column = '*')
     {
         if ($column != '*') {
-            $column = ($this->distinct() ? 'DISTINCT ' : '') . $this->db->escapeIdentifier($column);
+            $column = ($this->distinct ? 'DISTINCT ' : '') . $this->db->escapeIdentifier($column);
         }
 
 
@@ -450,6 +450,7 @@ class Table
     {
         $sql = sprintf(
             'SELECT SUM(%s) FROM %s %s %s %s %s %s %s %s',
+            $column,
             $this->db->escapeIdentifier($this->name),
             implode(' ', $this->joins),
             $this->conditionBuilder->build(),
@@ -461,6 +462,7 @@ class Table
         );
 
         $rq = $this->db->execute($sql, array_merge($this->conditionBuilder->getValues(), $this->aggregatedConditionBuilder->getValues()));
+        $result = $rq->fetchColumn();
 
         return $result ? (float) $result : 0;
     }

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -37,6 +37,8 @@ use PicoDb\Builder\UpdateBuilder;
  * @method   $this   gteSubquery($column, Table $subquery)
  * @method   $this   lte($column, $value)
  * @method   $this   lteSubquery($column, Table $subquery)
+ * @method   $this   between($column, $lowValue, $highValue)
+ * @method   $this   notBetween($column, $lowValue, $highValue)
  * @method   $this   isNull($column)
  * @method   $this   notNull($column)
  */

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -28,6 +28,7 @@ use PicoDb\Builder\UpdateBuilder;
  * @method   $this   notInSubquery($column, Table $subquery)
  * @method   $this   like($column, $value)
  * @method   $this   ilike($column, $value)
+ * @method   $this   notLike($column, $value)
  * @method   $this   gt($column, $value)
  * @method   $this   gtSubquery($column, Table $subquery)
  * @method   $this   lt($column, $value)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,7 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
-        colors="true"
-        stopOnError="true"
-        stopOnFailure="true">
+        colors="true">
     <testsuites>
         <testsuite name="sqlite">
             <file>tests/UrlParserTest.php</file>

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -71,21 +71,21 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     public function testLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE BINARY ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`  WHERE `a` LIKE BINARY ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->ilike('a', 'test');
-        $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`  WHERE `a` LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testNotLike()
     {
         $query = $this->db->table('test')->notLike('a', 'test');
-        $this->assertEquals('SELECT * FROM `test`    WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -446,7 +446,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
             ->eq('status', 0)
             ->inSubquery('foo', $subQuery);
 
-        $this->assertEquals('SELECT * FROM `foobar`   WHERE `foo` IN (SELECT foo FROM `foopoints`   GROUP BY `foo`  HAVING SUM(foopoints.points) > ?)', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `foobar`   WHERE `status` = ? AND `foo` IN (SELECT foo FROM `foopoints`   GROUP BY `foo`  HAVING SUM(foopoints.points) > ?)', $query->buildSelectQuery());
         $this->assertEquals([15], $query->getAggregatedConditionBuilder()->getValues());
         $this->assertEquals(6, $query->sum('foo'));
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -302,10 +302,11 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
         $subQuery = $this->db
             ->table('foobar')
+            ->select('foo')
             ->neq('foo', 2)
             ->groupBy('foobar.foo')
             ->having()
-            ->gt('SUM(foobar.bar)', 100);
+            ->gt('SUM( bar )', 100);
 
         $query = $this->db->table('foo')
             ->inSubquery('foo', $subQuery);

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -439,12 +439,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
             ->select('foo')
             ->groupBy('foo')
             ->having()
-            ->gt('SUM( points )', 15);
+            ->gt('SUM(foopoints.points)', 15);
 
         $query = $this->db
             ->table('foobar')
             ->inSubquery('foo', $subQuery);
 
+        $this->assertEquals('SELECT * FROM `foobar`   WHERE `foo` IN (SELECT foo FROM `foopoints`   GROUP BY `foo`  HAVING SUM(foopoints.points) > ?)', $query->buildSelectQuery());
+        $this->assertEquals([15], $query->getAggregatedConditionBuilder()->getValues());
         $this->assertEquals(6, $query->sum('foo'));
 
         $this->db->execute('DROP TABLE IF EXISTS foopoints');

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -68,6 +68,27 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('SELECT * FROM `test`      ORDER BY `a` DESC, `b` ASC', $this->db->table('test')->desc('a')->asc('b')->buildSelectQuery());
     }
 
+    public function testLike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE BINARY ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
+    public function testIlike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
+    public function testNotLike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
     public function testLimit()
     {
         $this->assertEquals('SELECT * FROM `test`       LIMIT 10', $this->db->table('test')->limit(10)->buildSelectQuery());

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -302,17 +302,16 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
         $subQuery = $this->db
             ->table('foobar')
-            ->select('foo')
-            ->gt('SUM(foobar.bar)', 100)
+            ->neq('foo', 2)
             ->groupBy('foobar.foo')
             ->having()
-            ->neq('foo', 2);
+            ->gt('SUM(foobar.bar)', 100);
 
         $query = $this->db->table('foo')
             ->inSubquery('foo', $subQuery);
 
         $this->assertEquals([2], $query->getAggregatedConditionBuilder()->getValues());
-        $this->assertEquals(4, $query->count());
+        $this->assertEquals(2, $query->count());
     }
 
     public function testCustomCondition()

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -71,21 +71,21 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     public function testLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE BINARY ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE BINARY ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testNotLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`    WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -71,14 +71,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     public function testLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test`  WHERE `a` LIKE BINARY ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE BINARY ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->ilike('a', 'test');
-        $this->assertEquals('SELECT * FROM `test`  WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -223,16 +223,23 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
-        
+
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
-        $this->assertEquals(3, $query->count('a', true));
-        $this->assertEquals(4, $query->count('b', true));
+        $this->assertEquals(5, $query->count('a'));
+        $this->assertEquals(5, $query->count('b'));
 
         $query->eq('b', 3);
         $this->assertEquals(2, $query->count());
-        $this->assertEquals(2, $query->count('a', true));
-        $this->assertEquals(1, $query->count('b', true));
+        $this->assertEquals(1, $query->count('a'));
+        $this->assertEquals(2, $query->count('b'));
+
+        $distinctQuery = $this->db
+            ->table('foobar')
+            ->distinct();
+        $this->assertEquals(5, $distinctQuery->count());
+        $this->assertEquals(3, $distinctQuery->count('a'));
+        $this->assertEquals(4, $distinctQuery->count('b'));
     }
 
     public function testCustomCondition()

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -310,7 +310,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $query = $this->db->table('foo')
             ->inSubquery('foo', $subQuery);
 
-        $this->assertEquals([2], $query->getAggregatedConditionBuilder()->getValues());
+        $this->assertEquals([100], $query->getAggregatedConditionBuilder()->getValues());
         $this->assertEquals(2, $query->count());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -72,21 +72,21 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE BINARY ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testNotLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM `test`    WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testLimit()
@@ -258,6 +258,8 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => null, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
+
+
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->count('a'));

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -278,6 +278,43 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(4, $distinctQuery->count('b'));
     }
 
+    public function testCountSubQueryHaving()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foo (foo INTEGER)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (foo INTEGER, bar INTEGER)'));
+
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 1]));
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 2]));
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 3]));
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 4]));
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 5]));
+
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 1, 'bar' => 128]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 2, 'bar' => 542]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 3, 'bar' => 8]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 4, 'bar' => 9]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 5, 'bar' => 643]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 1, 'bar' => 12]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 2, 'bar' => 6]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 3, 'bar' => 85]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 4, 'bar' => 91]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 5, 'bar' => 643]));
+
+        $subQuery = $this->db
+            ->table('foobar')
+            ->select('foo')
+            ->neq('foo', 2)
+            ->groupBy('foobar.foo')
+            ->having()
+            ->gt('bar', 100);
+
+        $query = $this->db->table('foo')
+            ->inSubquery('foo', $subQuery);
+
+        $this->assertEquals([100], $query->getAggregatedConditionBuilder()->getValues());
+        $this->assertEquals(2, $query->count());
+    }
+
     public function testCustomCondition()
     {
         $table = $this->db->table('test');

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -77,7 +77,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
     public function testIlike()
     {
-        $query = $this->db->table('test')->like('a', 'test');
+        $query = $this->db->table('test')->ilike('a', 'test');
         $this->assertEquals('SELECT * FROM `test`   WHERE `a` LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -221,9 +221,8 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 1)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
-        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => null, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
-
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
         $this->assertEquals(5, $query->count('a'));

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -443,6 +443,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('foobar')
+            ->eq('status', 0)
             ->inSubquery('foo', $subQuery);
 
         $this->assertEquals('SELECT * FROM `foobar`   WHERE `foo` IN (SELECT foo FROM `foopoints`   GROUP BY `foo`  HAVING SUM(foopoints.points) > ?)', $query->buildSelectQuery());

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -231,14 +231,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     public function testBetween()
     {
         $query = $this->db->table('test')->between('a', 1, 5);
-        $this->assertEquals('SELECT * FROM `test`   WHERE `a` BETWEEN ? AND ?');
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` BETWEEN ? AND ?', $query->buildSelectQuery());
         $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
     }
 
     public function testNotBetween()
     {
         $query = $this->db->table('test')->notBetween('a', 1, 5);
-        $this->assertEquals('SELECT * FROM `test`   WHERE `a` NOT BETWEEN ? AND ?');
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` NOT BETWEEN ? AND ?', $query->buildSelectQuery());
         $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
     }
     

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -412,6 +412,44 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(7, $this->db->table('foobar')->sum('a'));
     }
 
+    public function testSumSubqueryHaving()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar(foo INTEGER, status INTEGER DEFAULT 0)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foopoints(foo INTEGER, points INTEGER)'));
+
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>1, 'status'=>0)));
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>2, 'status'=>0)));
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>3, 'status'=>1)));
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>4, 'status'=>0)));
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>5, 'status'=>1)));
+
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>1, 'points'=>8)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>1, 'points'=>2)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>2, 'points'=>18)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>2, 'points'=>3)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>3, 'points'=>7)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>3, 'points'=>8)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>4, 'points'=>12)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>4, 'points'=>7)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>5, 'points'=>18)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>5, 'points'=>8)));
+
+        $subQuery = $this->db
+            ->table('foopoints')
+            ->select('foo')
+            ->groupBy('foo')
+            ->having()
+            ->gt('SUM( points )', 15);
+
+        $query = $this->db
+            ->table('foobar')
+            ->inSubquery('foo', $subQuery);
+
+        $this->assertEquals(6, $query->sum('foo'));
+
+        $this->db->execute('DROP TABLE IF EXISTS foopoints');
+    }
+
     public function testIncrement()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (a INTEGER DEFAULT 0, b INTEGER DEFAULT 0)'));

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -84,7 +84,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
     public function testNotLike()
     {
-        $query = $this->db->table('test')->like('a', 'test');
+        $query = $this->db->table('test')->notLike('a', 'test');
         $this->assertEquals('SELECT * FROM `test`    WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -262,7 +262,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
-        $this->assertEquals(5, $query->count('a'));
+        $this->assertEquals(4, $query->count('a'));
         $this->assertEquals(5, $query->count('b'));
 
         $query->eq('b', 3);

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -303,16 +303,16 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $subQuery = $this->db
             ->table('foobar')
             ->select('foo')
-            ->neq('foo', 2)
+            ->gt('SUM(foobar.bar)', 100)
             ->groupBy('foobar.foo')
             ->having()
-            ->gt('bar', 100);
+            ->neq('foo', 2);
 
         $query = $this->db->table('foo')
             ->inSubquery('foo', $subQuery);
 
-        $this->assertEquals([100], $query->getAggregatedConditionBuilder()->getValues());
-        $this->assertEquals(2, $query->count());
+        $this->assertEquals([2], $query->getAggregatedConditionBuilder()->getValues());
+        $this->assertEquals(4, $query->count());
     }
 
     public function testCustomCondition()

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -228,6 +228,20 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(5), $table->getConditionBuilder()->getValues());
     }
 
+    public function testBetween()
+    {
+        $query = $this->db->table('test')->between('a', 1, 5);
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` BETWEEN ? AND ?');
+        $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
+    }
+
+    public function testNotBetween()
+    {
+        $query = $this->db->table('test')->notBetween('a', 1, 5);
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` NOT BETWEEN ? AND ?');
+        $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
+    }
+    
     public function testConditionIsNull()
     {
         $table = $this->db->table('test');

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -311,7 +311,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
             ->inSubquery('foo', $subQuery);
 
         $this->assertEquals([100], $query->getAggregatedConditionBuilder()->getValues());
-        $this->assertEquals(4, $query->count());
+        $this->assertEquals(2, $query->count());
     }
 
     public function testCustomCondition()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -70,21 +70,21 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     public function testLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` ILIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" ILIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testNotLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -445,7 +445,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
             ->eq('status', 0)
             ->inSubquery('foo', $subQuery);
 
-        $this->assertEquals('SELECT * FROM "foobar"   WHERE "foo" IN (SELECT foo FROM "foopoints"   GROUP BY "foo"  HAVING SUM(foopoints.points) > ?)', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "foobar"   WHERE "status" = ? AND "foo" IN (SELECT foo FROM "foopoints"   GROUP BY "foo"  HAVING SUM(foopoints.points) > ?)', $query->buildSelectQuery());
         $this->assertEquals([15], $query->getAggregatedConditionBuilder()->getValues());
         $this->assertEquals(6, $query->sum('foo'));
 

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -76,7 +76,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
 
     public function testIlike()
     {
-        $query = $this->db->table('test')->like('a', 'test');
+        $query = $this->db->table('test')->ilike('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" ILIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -71,21 +71,21 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" LIKE ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" ILIKE ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testNotLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT LIKE ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testLimit()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -230,14 +230,14 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     public function testBetween()
     {
         $query = $this->db->table('test')->between('a', 1, 5);
-        $this->assertEquals('SELECT * FROM "test"   WHERE "a" BETWEEN ? AND ?');
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" BETWEEN ? AND ?', $query->buildSelectQuery());
         $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
     }
 
     public function testNotBetween()
     {
         $query = $this->db->table('test')->notBetween('a', 1, 5);
-        $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT BETWEEN ? AND ?');
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT BETWEEN ? AND ?', $query->buildSelectQuery());
         $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
     }
 

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -227,6 +227,20 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(5), $table->getConditionBuilder()->getValues());
     }
 
+    public function testBetween()
+    {
+        $query = $this->db->table('test')->between('a', 1, 5);
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" BETWEEN ? AND ?');
+        $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
+    }
+
+    public function testNotBetween()
+    {
+        $query = $this->db->table('test')->notBetween('a', 1, 5);
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT BETWEEN ? AND ?');
+        $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
+    }
+
     public function testConditionIsNull()
     {
         $table = $this->db->table('test');

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -67,6 +67,27 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('SELECT * FROM "test"      ORDER BY "a" DESC, "b" ASC', $this->db->table('test')->desc('a')->asc('b')->buildSelectQuery());
     }
 
+    public function testLike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
+    public function testIlike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` ILIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
+    public function testNotLike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
     public function testLimit()
     {
         $this->assertEquals('SELECT * FROM "test"       LIMIT 10', $this->db->table('test')->limit(10)->buildSelectQuery());
@@ -225,7 +246,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
-        $this->assertEquals(5, $query->count('a'));
+        $this->assertEquals(4, $query->count('a'));
         $this->assertEquals(5, $query->count('b'));
 
         $query->eq('b', 3);

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -83,7 +83,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
 
     public function testNotLike()
     {
-        $query = $this->db->table('test')->like('a', 'test');
+        $query = $this->db->table('test')->notLike('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -305,13 +305,13 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
             ->neq('foo', 2)
             ->groupBy('foobar.foo')
             ->having()
-            ->gt('bar', 100);
+            ->gt('SUM(foobar.bar)', 100);
 
         $query = $this->db->table('foo')
             ->inSubquery('foo', $subQuery);
 
         $this->assertEquals([100], $query->getAggregatedConditionBuilder()->getValues());
-        $this->assertEquals(2, $query->count());
+        $this->assertEquals(4, $query->count());
     }
 
     public function testCustomCondition()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -220,17 +220,26 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 1)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
-        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => null, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
+
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
-        $this->assertEquals(3, $query->count('a', true));
-        $this->assertEquals(4, $query->count('b', true));
+        $this->assertEquals(5, $query->count('a'));
+        $this->assertEquals(5, $query->count('b'));
 
         $query->eq('b', 3);
         $this->assertEquals(2, $query->count());
-        $this->assertEquals(2, $query->count('a', true));
-        $this->assertEquals(1, $query->count('b', true));
+        $this->assertEquals(1, $query->count('a'));
+        $this->assertEquals(2, $query->count('b'));
+
+        $distinctQuery = $this->db
+            ->table('foobar')
+            ->distinct();
+        $this->assertEquals(5, $distinctQuery->count());
+        $this->assertEquals(3, $distinctQuery->count('a'));
+        $this->assertEquals(4, $distinctQuery->count('b'));
+
     }
 
     public function testCustomCondition()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -438,12 +438,14 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
             ->select('foo')
             ->groupBy('foo')
             ->having()
-            ->gt('SUM(points)', 15);
+            ->gt('SUM(foopoints.points)', 15);
 
         $query = $this->db
             ->table('foobar')
             ->inSubquery('foo', $subQuery);
 
+        $this->assertEquals('SELECT * FROM "foobar"   WHERE "foo" IN (SELECT foo FROM "foopoints"   GROUP BY "foo"  HAVING SUM(foopoints.points) > ?)', $query->buildSelectQuery());
+        $this->assertEquals([15], $query->getAggregatedConditionBuilder()->getValues());
         $this->assertEquals(6, $query->sum('foo'));
 
         $this->db->execute('DROP TABLE IF EXISTS foopoints');

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -442,6 +442,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('foobar')
+            ->eq('status', 0)
             ->inSubquery('foo', $subQuery);
 
         $this->assertEquals('SELECT * FROM "foobar"   WHERE "foo" IN (SELECT foo FROM "foopoints"   GROUP BY "foo"  HAVING SUM(foopoints.points) > ?)', $query->buildSelectQuery());

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -65,21 +65,21 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     public function testLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test" WHERE "a" LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test" WHERE "a" LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testNotLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM `test` WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test" WHERE "a" NOT LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -78,7 +78,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
 
     public function testNotLike()
     {
-        $query = $this->db->table('test')->like('a', 'test');
+        $query = $this->db->table('test')->notLike('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -71,7 +71,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
 
     public function testIlike()
     {
-        $query = $this->db->table('test')->like('a', 'test');
+        $query = $this->db->table('test')->ilike('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -530,11 +530,12 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('foobar')
+            ->eq('status', 0)
             ->inSubquery('foo', $subQuery);
 
         $this->assertEquals('SELECT * FROM "foobar"   WHERE "foo" IN (SELECT foo FROM "foopoints"   GROUP BY "foo"  HAVING "points" > ?)', $query->buildSelectQuery());
         $this->assertEquals([10], $query->getAggregatedConditionBuilder()->getValues());
-        $this->assertEquals(11, $query->sum('foo'));
+        $this->assertEquals(6, $query->sum('foo'));
 
         $this->db->execute('DROP TABLE IF EXISTS foopoints');
     }

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -267,7 +267,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 1)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
-        $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('a' => null, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
 
         $query = $this->db->table('foobar');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -323,6 +323,43 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(4, $distinctQuery->count('b'));
     }
 
+    public function testCountSubQueryHaving()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foo (foo INTEGER)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (foo INTEGER, bar INTEGER)'));
+
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 1]));
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 2]));
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 3]));
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 4]));
+        $this->assertTrue($this->db->table('foo')->insert(['foo' => 5]));
+
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 1, 'bar' => 128]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 2, 'bar' => 542]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 3, 'bar' => 8]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 4, 'bar' => 9]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 5, 'bar' => 643]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 1, 'bar' => 12]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 2, 'bar' => 6]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 3, 'bar' => 85]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 4, 'bar' => 91]));
+        $this->assertTrue($this->db->table('foobar')->insert(['foo' => 5, 'bar' => 643]));
+
+        $subQuery = $this->db
+            ->table('foobar')
+            ->select('foo')
+            ->neq('foo', 2)
+            ->groupBy('foobar.foo')
+            ->having()
+            ->gt('bar', 100);
+
+        $query = $this->db->table('foo')
+            ->inSubquery('foo', $subQuery);
+
+        $this->assertEquals([100], $query->getAggregatedConditionBuilder()->getValues());
+        $this->assertEquals(2, $query->count());
+    }
+
     public function testCustomCondition()
     {
         $table = $this->db->table('test');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -65,21 +65,21 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     public function testLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM "test" WHERE "a" LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM "test" WHERE "a" LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testNotLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
-        $this->assertEquals('SELECT * FROM "test" WHERE "a" NOT LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT LIKE ?', $query->buildSelectQuery());
         $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
     }
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -274,6 +274,20 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array('e'), $table->getConditionBuilder()->getValues());
     }
 
+    public function testBetween()
+    {
+        $query = $this->db->table('test')->between('a', 1, 5);
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" BETWEEN ? AND ?');
+        $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
+    }
+
+    public function testNotBetween()
+    {
+        $query = $this->db->table('test')->notBetween('a', 1, 5);
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT BETWEEN ? AND ?');
+        $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
+    }
+
     public function testConditionIsNull()
     {
         $table = $this->db->table('test');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -277,14 +277,14 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     public function testBetween()
     {
         $query = $this->db->table('test')->between('a', 1, 5);
-        $this->assertEquals('SELECT * FROM "test"   WHERE "a" BETWEEN ? AND ?');
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" BETWEEN ? AND ?', $query->buildSelectQuery());
         $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
     }
 
     public function testNotBetween()
     {
         $query = $this->db->table('test')->notBetween('a', 1, 5);
-        $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT BETWEEN ? AND ?');
+        $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT BETWEEN ? AND ?', $query->buildSelectQuery());
         $this->assertEquals([1,5], $query->getConditionBuilder()->getValues());
     }
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -532,6 +532,8 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
             ->table('foobar')
             ->inSubquery('foo', $subQuery);
 
+        $this->assertEquals('SELECT * FROM "foobar"   WHERE "foo" IN (SELECT foo FROM "foopoints"   GROUP BY "foo"  HAVING "points" > ?)', $query->buildSelectQuery());
+        $this->assertEquals([10], $query->getAggregatedConditionBuilder()->getValues());
         $this->assertEquals(11, $query->sum('foo'));
 
         $this->db->execute('DROP TABLE IF EXISTS foopoints');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -62,6 +62,27 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('SELECT * FROM "test"      ORDER BY "a" DESC, "b" ASC', $this->db->table('test')->desc('a')->asc('b')->buildSelectQuery());
     }
 
+    public function testLike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
+    public function testIlike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
+    public function testNotLike()
+    {
+        $query = $this->db->table('test')->like('a', 'test');
+        $this->assertEquals('SELECT * FROM `test` WHERE `a` NOT LIKE ?', $query->buildSelectQuery());
+        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+    }
+
     public function testLimit()
     {
         $this->assertEquals('SELECT * FROM "test"       LIMIT 10', $this->db->table('test')->limit(10)->buildSelectQuery());
@@ -272,7 +293,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
-        $this->assertEquals(5, $query->count('a'));
+        $this->assertEquals(4, $query->count('a'));
         $this->assertEquals(5, $query->count('b'));
 
         $query->eq('b', 3);

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -269,15 +269,23 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 6, 'b' => 2)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 5, 'b' => 3)));
         $this->assertTrue($this->db->table('foobar')->insert(array('a' => 2, 'b' => 4)));
+
         $query = $this->db->table('foobar');
         $this->assertEquals(5, $query->count());
-        $this->assertEquals(3, $query->count('a', true));
-        $this->assertEquals(4, $query->count('b', true));
+        $this->assertEquals(5, $query->count('a'));
+        $this->assertEquals(5, $query->count('b'));
 
         $query->eq('b', 3);
         $this->assertEquals(2, $query->count());
-        $this->assertEquals(2, $query->count('a', true));
-        $this->assertEquals(1, $query->count('b', true));
+        $this->assertEquals(1, $query->count('a'));
+        $this->assertEquals(2, $query->count('b'));
+
+        $distinctQuery = $this->db
+            ->table('foobar')
+            ->distinct();
+        $this->assertEquals(5, $distinctQuery->count());
+        $this->assertEquals(3, $distinctQuery->count('a'));
+        $this->assertEquals(4, $distinctQuery->count('b'));
     }
 
     public function testCustomCondition()

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -499,6 +499,44 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(7, $this->db->table('foobar')->sum('a'));
     }
 
+    public function testSumSubqueryHaving()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar(foo INTEGER, status INTEGER DEFAULT 0)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foopoints(foo INTEGER, points INTEGER)'));
+
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>1, 'status'=>0)));
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>2, 'status'=>0)));
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>3, 'status'=>1)));
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>4, 'status'=>0)));
+        $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>5, 'status'=>1)));
+
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>1, 'points'=>8)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>1, 'points'=>2)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>2, 'points'=>18)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>2, 'points'=>3)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>3, 'points'=>7)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>3, 'points'=>8)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>4, 'points'=>12)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>4, 'points'=>7)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>5, 'points'=>18)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>5, 'points'=>8)));
+
+        $subQuery = $this->db
+            ->table('foopoints')
+            ->select('foo')
+            ->groupBy('foo')
+            ->having()
+            ->gt('points', 10);
+
+        $query = $this->db
+            ->table('foobar')
+            ->inSubquery('foo', $subQuery);
+
+        $this->assertEquals(11, $query->sum('foo'));
+
+        $this->db->execute('DROP TABLE IF EXISTS foopoints');
+    }
+
     public function testIncrement()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (a INTEGER DEFAULT 0, b INTEGER DEFAULT 0)'));

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -66,21 +66,21 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" LIKE ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testIlike()
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" LIKE ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testNotLike()
     {
         $query = $this->db->table('test')->like('a', 'test');
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" NOT LIKE ?', $query->buildSelectQuery());
-        $this->assertEquals('a', $query->getConditionBuilder()->getValues()[0]);
+        $this->assertEquals('test', $query->getConditionBuilder()->getValues()[0]);
     }
 
     public function testLimit()

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -510,7 +510,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>4, 'status'=>0)));
         $this->assertNotFalse($this->db->table('foobar')->insert(array('foo'=>5, 'status'=>1)));
 
-        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>1, 'points'=>8)));
+        $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>1, 'points'=>10)));
         $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>1, 'points'=>2)));
         $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>2, 'points'=>18)));
         $this->assertNotFalse($this->db->table('foopoints')->insert(array('foo'=>2, 'points'=>3)));
@@ -533,7 +533,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
             ->eq('status', 0)
             ->inSubquery('foo', $subQuery);
 
-        $this->assertEquals('SELECT * FROM "foobar"   WHERE "foo" IN (SELECT foo FROM "foopoints"   GROUP BY "foo"  HAVING "points" > ?)', $query->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "foobar"   WHERE "status" = ? AND "foo" IN (SELECT foo FROM "foopoints"   GROUP BY "foo"  HAVING "points" > ?)', $query->buildSelectQuery());
         $this->assertEquals([10], $query->getAggregatedConditionBuilder()->getValues());
         $this->assertEquals(6, $query->sum('foo'));
 


### PR DESCRIPTION
This PR has a number of enhancements + fixes.

1. Fixes issues that `Table::count` and similar functions were having with subqueries that have `->having` applied to them. This makes them more like `findAll`
2. Removes the `$distinct` argument for the `count` function and make use of the `->distinct()` function. (As I do believe I'm the only one using this, I'm comfortable doing this)
3. Adds unit tests for `like` and `ilike` functions
4. Adds `notLike` function, and associated unit tests
5. Adds `between` and `notBetween` functions. 
