### PR TITLE
Add the ability to join onto a subquery

### DIFF
--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -409,7 +409,7 @@ class Table
             $this->sqlOffset
         );
 
-        $rq = $this->db->execute($sql, array_merge($this->conditionBuilder->getValues(), $this->aggregatedConditionBuilder->getValues()));
+        $rq = $this->db->execute($sql,  $this->getValues());
         $result = $rq->fetchColumn();
 
         return $result ? true : false;
@@ -441,7 +441,7 @@ class Table
             $this->sqlOffset
         );
 
-        $rq = $this->db->execute($sql, array_merge($this->conditionBuilder->getValues(), $this->aggregatedConditionBuilder->getValues()));
+        $rq = $this->db->execute($sql,  $this->getValues());
         $result = $rq->fetchColumn();
 
         return $result ? (int) $result : 0;
@@ -469,7 +469,7 @@ class Table
             $this->sqlOffset
         );
 
-        $rq = $this->db->execute($sql, array_merge($this->conditionBuilder->getValues(), $this->aggregatedConditionBuilder->getValues()));
+        $rq = $this->db->execute($sql, $this->getValues());
         $result = $rq->fetchColumn();
 
         return $result ? (float) $result : 0;

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -318,7 +318,7 @@ class Table
      */
     public function findAll()
     {
-        $rq = $this->db->execute($this->buildSelectQuery(), array_merge($this->joinValues, $this->conditionBuilder->getValues(), $this->aggregatedConditionBuilder->getValues()));
+        $rq = $this->db->execute($this->buildSelectQuery(), $this->getValues());
         $results = $rq->fetchAll(PDO::FETCH_ASSOC);
 
         if (is_callable($this->callback) && ! empty($results)) {
@@ -338,7 +338,7 @@ class Table
     public function findAllByColumn($column)
     {
         $this->columns = array($column);
-        $rq = $this->db->execute($this->buildSelectQuery(), array_merge($this->conditionBuilder->getValues(), $this->aggregatedConditionBuilder->getValues()));
+        $rq = $this->db->execute($this->buildSelectQuery(), $this->getValues());
 
         return $rq->fetchAll(PDO::FETCH_COLUMN, 0);
     }
@@ -369,7 +369,7 @@ class Table
         $this->limit(1);
         $this->columns = array($column);
 
-        return $this->db->execute($this->buildSelectQuery(), array_merge($this->conditionBuilder->getValues(), $this->aggregatedConditionBuilder->getValues()))->fetchColumn();
+        return $this->db->execute($this->buildSelectQuery(), $this->getValues())->fetchColumn();
     }
 
     /**
@@ -879,4 +879,13 @@ class Table
              $this->aggregatedConditionBuilder->addValues($subquery->getAggregatedConditionBuilder()->getValues());
          }
      }
+
+     private function getValues()
+    {
+        return array_merge(
+            $this->joinValues,
+            $this->getConditionBuilder()->getValues(),
+            $this->getAggregatedConditionBuilder()->getValues()
+        );
+    }
 }

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -508,11 +508,12 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('test1 t1')
+            ->select('id, a, b')
             ->joinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
-            ->select('id, a, b');
+            ->orderBy('id');
 
         $this->assertEquals(
-            'SELECT id, a, b FROM test1 t1 LEFT JOIN (SELECT * FROM `test2`   WHERE `b` = ?) AS `b` ON `b`.`foreign_key`=`t1`.`id`',
+            'SELECT id, a, b FROM test1 t1 LEFT JOIN (SELECT * FROM `test2`   WHERE `b` = ?) AS `b` ON `b`.`foreign_key`=`t1`.`id`     ORDER BY `id` ASC',
             $query->buildSelectQuery()
         );
 
@@ -563,11 +564,12 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('test1 t1')
+            ->select('id, a, b')
             ->innerJoinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
-            ->select('id, a, b');
+            ->orderBy('id');
 
         $this->assertEquals(
-            'SELECT id, a, b FROM test1 t1 INNER JOIN (SELECT * FROM `test2`   WHERE `b` = ?) AS `b` ON `b`.`foreign_key`=`t1`.`id`',
+            'SELECT id, a, b FROM test1 t1 INNER JOIN (SELECT * FROM `test2`   WHERE `b` = ?) AS `b` ON `b`.`foreign_key`=`t1`.`id`     ORDER BY `id` ASC',
             $query->buildSelectQuery()
         );
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -485,6 +485,104 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testJoinSubquery()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (foreign_key INTEGER NOT NULL, b INTEGER)'));
+
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 1, 'a' => 5)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 2, 'a' => 1)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 3, 'a' => 14)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 4, 'a' => 6)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 5, 'a' => 12)));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 1, 'b' => 185)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 2, 'b' => 146)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 3, 'b' => 185)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 4, 'b' => 34)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 5, 'b' => 121)));
+
+        $subQuery = $this->db
+            ->table('test2')
+            ->eq('b', 185);
+
+        $query = $this->db
+            ->table('test1 t1')
+            ->joinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
+            ->select('id, a, b');
+
+        $this->assertEquals(
+            'SELECT id, a, b FROM test1 t1 LEFT JOIN (SELECT * FROM `test2`   WHERE `b` = ?) AS `b` ON `b`.`foreign_key`=`t1`.`id`',
+            $query->buildSelectQuery()
+        );
+
+        $results = $query->findAll();
+        $this->assertCount(5, $results);
+        $this->assertEquals(
+            ['id' => 1, 'a' => 5, 'b' => 185],
+            $results[0]
+        );
+        $this->assertEquals(
+            ['id' => 2, 'a' => 1, 'b' => null],
+            $results[1]
+        );
+        $this->assertEquals(
+            ['id' => 3, 'a' => 14, 'b' => 185],
+            $results[2]
+        );
+        $this->assertEquals(
+            ['id' => 4, 'a' => 6, 'b' => null],
+            $results[3]
+        );
+        $this->assertEquals(
+            ['id' => 5, 'a' => 12, 'b' => null],
+            $results[4]
+        );
+    }
+
+    public function testInnerJoinSubquery()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (foreign_key INTEGER NOT NULL, b INTEGER)'));
+
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 1, 'a' => 5)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 2, 'a' => 1)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 3, 'a' => 14)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 4, 'a' => 6)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 5, 'a' => 12)));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 1, 'b' => 185)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 2, 'b' => 146)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 3, 'b' => 185)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 4, 'b' => 34)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 5, 'b' => 121)));
+
+        $subQuery = $this->db
+            ->table('test2')
+            ->eq('b', 185);
+
+        $query = $this->db
+            ->table('test1 t1')
+            ->innerJoinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
+            ->select('id, a, b');
+
+        $this->assertEquals(
+            'SELECT id, a, b FROM test1 t1 INNER JOIN (SELECT * FROM `test2`   WHERE `b` = ?) AS `b` ON `b`.`foreign_key`=`t1`.`id`',
+            $query->buildSelectQuery()
+        );
+
+        $results = $query->findAll();
+        $this->assertCount(2, $results);
+        $this->assertEquals(
+            ['id' => 1, 'a' => 5, 'b' => 185],
+            $results[0]
+        );
+        $this->assertEquals(
+            ['id' => 3, 'a' => 14, 'b' => 185],
+            $results[1]
+        );
+    }
+
     public function testHashTable()
     {
         $this->assertNotFalse($this->db->execute(

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -507,11 +507,12 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('test1 t1')
+            ->select('id, a, b')
             ->joinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
-            ->select('id, a, b');
+            ->orderBy('id');
 
         $this->assertEquals(
-            'SELECT id, a, b FROM test1 t1 LEFT JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"',
+            'SELECT id, a, b FROM test1 t1 LEFT JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"     ORDER BY "id" ASC',
             $query->buildSelectQuery()
         );
 
@@ -562,11 +563,12 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('test1 t1')
+            ->select('id, a, b')
             ->innerJoinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
-            ->select('id, a, b');
+            ->orderBy('id');
 
         $this->assertEquals(
-            'SELECT id, a, b FROM test1 t1 INNER JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"',
+            'SELECT id, a, b FROM test1 t1 INNER JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"     ORDER BY "id" ASC',
             $query->buildSelectQuery()
         );
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -595,11 +595,12 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('test1 t1')
+            ->select('id, a, b')
             ->joinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
-            ->select('id, a, b');
+            ->orderBy('id');
 
         $this->assertEquals(
-            'SELECT id, a, b FROM test1 t1 LEFT JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"',
+            'SELECT id, a, b FROM test1 t1 LEFT JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"     ORDER BY "id" ASC',
             $query->buildSelectQuery()
         );
 
@@ -650,11 +651,12 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
 
         $query = $this->db
             ->table('test1 t1')
+            ->select('id, a, b')
             ->innerJoinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
-            ->select('id, a, b');
+            ->orderBy('id');
 
         $this->assertEquals(
-            'SELECT id, a, b FROM test1 t1 INNER JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"',
+            'SELECT id, a, b FROM test1 t1 INNER JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"     ORDER BY "id" ASC',
             $query->buildSelectQuery()
         );
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -572,6 +572,104 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testJoinSubquery()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (foreign_key INTEGER NOT NULL, b INTEGER)'));
+
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 1, 'a' => 5)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 2, 'a' => 1)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 3, 'a' => 14)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 4, 'a' => 6)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 5, 'a' => 12)));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 1, 'b' => 185)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 2, 'b' => 146)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 3, 'b' => 185)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 4, 'b' => 34)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 5, 'b' => 121)));
+
+        $subQuery = $this->db
+            ->table('test2')
+            ->eq('b', 185);
+
+        $query = $this->db
+            ->table('test1 t1')
+            ->joinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
+            ->select('id, a, b');
+
+        $this->assertEquals(
+            'SELECT id, a, b FROM test1 t1 LEFT JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"',
+            $query->buildSelectQuery()
+        );
+
+        $results = $query->findAll();
+        $this->assertCount(5, $results);
+        $this->assertEquals(
+            ['id' => 1, 'a' => 5, 'b' => 185],
+            $results[0]
+        );
+        $this->assertEquals(
+            ['id' => 2, 'a' => 1, 'b' => null],
+            $results[1]
+        );
+        $this->assertEquals(
+            ['id' => 3, 'a' => 14, 'b' => 185],
+            $results[2]
+        );
+        $this->assertEquals(
+            ['id' => 4, 'a' => 6, 'b' => null],
+            $results[3]
+        );
+        $this->assertEquals(
+            ['id' => 5, 'a' => 12, 'b' => null],
+            $results[4]
+        );
+    }
+
+    public function testInnerJoinSubquery()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (foreign_key INTEGER NOT NULL, b INTEGER)'));
+
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 1, 'a' => 5)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 2, 'a' => 1)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 3, 'a' => 14)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 4, 'a' => 6)));
+        $this->assertTrue($this->db->table('test1')->insert(array('id'=> 5, 'a' => 12)));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 1, 'b' => 185)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 2, 'b' => 146)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 3, 'b' => 185)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 4, 'b' => 34)));
+        $this->assertTrue($this->db->table('test2')->insert(array('foreign_key'=> 5, 'b' => 121)));
+
+        $subQuery = $this->db
+            ->table('test2')
+            ->eq('b', 185);
+
+        $query = $this->db
+            ->table('test1 t1')
+            ->innerJoinSubquery($subQuery, 'b', 'foreign_key', 'id', 't1')
+            ->select('id, a, b');
+
+        $this->assertEquals(
+            'SELECT id, a, b FROM test1 t1 INNER JOIN (SELECT * FROM "test2"   WHERE "b" = ?) AS "b" ON "b"."foreign_key"="t1"."id"',
+            $query->buildSelectQuery()
+        );
+
+        $results = $query->findAll();
+        $this->assertCount(2, $results);
+        $this->assertEquals(
+            ['id' => 1, 'a' => 5, 'b' => 185],
+            $results[0]
+        );
+        $this->assertEquals(
+            ['id' => 3, 'a' => 14, 'b' => 185],
+            $results[1]
+        );
+    }
+
     public function testHashTable()
     {
         $this->assertNotFalse($this->db->execute(


### PR DESCRIPTION
This PR adds in the ability to perform a left join, or an inner join, onto a subquery, for those days when you just need to be extra.

![image](https://i.giphy.com/media/pjPfdL0lAmhuwcuM59/giphy.webp)


To do this:

- Add `joinSubquery` function that performs a left join on a given subquery
- Add `innerJoinSubquery` function that, surprisingly, performs an inner join on a given subquery
- Adds `joinValues` attribute to the `Table` class that pulls in the values of these subqueries so that we can build the queries correctly, so no values can exist outside of the `ConditionBuilder` classes
- Adds a `getValues` function to the `Table` class that is now used in place of merging the condition builder values. This function basically does the same thing, but _also_ merges in the `joinValues` values as well. 
