### PR TITLE
[HOTFIX] - User correct OFFSET/LIMIT syntax for MSSQL

### DIFF
--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -152,6 +152,28 @@ abstract class Base
     }
 
     /**
+     * Get offset limit clause
+     *
+     * @param int $limit
+     * @param int $offset
+     * @return string
+     */
+    public function getLimitClause($limit, $offset)
+    {
+        $clause = '';
+
+        if (! is_null($limit)) {
+            $clause .= ' LIMIT ' . $limit;
+        }
+
+        if (! is_null($offset)) {
+            $clause .= '  OFFSET ' . $offset;
+        }
+
+        return $clause;
+    }
+
+    /**
      * Upsert for a key/value variable
      *
      * @access public

--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -175,4 +175,26 @@ class Mssql extends Base
         $this->getConnection()->exec('SET SHOWPLAN_ALL ON');
         return $this->getConnection()->query($this->getSqlFromPreparedStatement($sql, $values))->fetchAll(PDO::FETCH_ASSOC);
     }
+
+    /**
+     * Get offset limit clause
+     *
+     * @param int $limit
+     * @param int $offset
+     * @return string
+     */
+    public function getLimitClause($limit, int $offset)
+    {
+        $clause = '';
+
+        if (! is_null($limit)) {
+            $clause .= ' FETCH NEXT '.$limit.' ROWS ONLY';
+        }
+
+        if (! is_null($offset)) {
+            $clause = ' OFFSET '.$offset.' ROWS';
+        }
+
+        return $clause;
+    }
 }

--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -183,7 +183,7 @@ class Mssql extends Base
      * @param int $offset
      * @return string
      */
-    public function getLimitClause($limit, int $offset)
+    public function getLimitClause($limit, $offset)
     {
         $clause = '';
 

--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -187,12 +187,12 @@ class Mssql extends Base
     {
         $clause = '';
 
-        if (! is_null($limit)) {
-            $clause .= ' FETCH NEXT '.$limit.' ROWS ONLY';
-        }
-
         if (! is_null($offset)) {
             $clause = ' OFFSET '.$offset.' ROWS';
+        }
+
+        if (! is_null($limit)) {
+            $clause .= ' FETCH NEXT '.$limit.' ROWS ONLY';
         }
 
         return $clause;

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -105,17 +105,17 @@ class Table
      * SQL limit
      *
      * @access private
-     * @var    string
+     * @var    int
      */
-    private $sqlLimit = '';
+    private $sqlLimit = null;
 
     /**
      * SQL offset
      *
      * @access private
-     * @var    string
+     * @var    int
      */
-    private $sqlOffset = '';
+    private $sqlOffset = null;
 
     /**
      * SQL order
@@ -398,15 +398,17 @@ class Table
     public function exists()
     {
         $sql = sprintf(
-            'SELECT 1 FROM %s %s %s %s %s %s %s %s',
+            'SELECT 1 FROM %s %s %s %s %s %s %s',
             $this->db->escapeIdentifier($this->name),
             implode(' ', $this->joins),
             $this->conditionBuilder->build(),
             empty($this->groupBy) ? '' : 'GROUP BY '.implode(', ', $this->groupBy),
             $this->aggregatedConditionBuilder->build(),
             $this->sqlOrder,
-            $this->sqlLimit,
-            $this->sqlOffset
+            $this->db->getDriver()->getLimitClause(
+                $this->sqlLimit,
+                $this->sqlOffset
+            )
         );
 
         $rq = $this->db->execute($sql,  $this->getValues());
@@ -430,15 +432,17 @@ class Table
 
 
         $sql = sprintf(
-            'SELECT COUNT(' . $column . ') FROM %s %s %s %s %s %s %s %s',
+            'SELECT COUNT(' . $column . ') FROM %s %s %s %s %s %s %s',
             $this->db->escapeIdentifier($this->name),
             implode(' ', $this->joins),
             $this->conditionBuilder->build(),
             empty($this->groupBy) ? '' : 'GROUP BY '.implode(', ', $this->groupBy),
             $this->aggregatedConditionBuilder->build(),
             $this->sqlOrder,
-            $this->sqlLimit,
-            $this->sqlOffset
+            $this->db->getDriver()->getLimitClause(
+                $this->sqlLimit,
+                $this->sqlOffset
+            )
         );
 
         $rq = $this->db->execute($sql,  $this->getValues());
@@ -457,7 +461,7 @@ class Table
     public function sum(string $column)
     {
         $sql = sprintf(
-            'SELECT SUM(%s) FROM %s %s %s %s %s %s %s %s',
+            'SELECT SUM(%s) FROM %s %s %s %s %s %s %s',
             $column,
             $this->db->escapeIdentifier($this->name),
             implode(' ', $this->joins),
@@ -465,8 +469,10 @@ class Table
             empty($this->groupBy) ? '' : 'GROUP BY '.implode(', ', $this->groupBy),
             $this->aggregatedConditionBuilder->build(),
             $this->sqlOrder,
-            $this->sqlLimit,
-            $this->sqlOffset
+            $this->db->getDriver()->getLimitClause(
+                $this->sqlLimit,
+                $this->sqlOffset
+            )
         );
 
         $rq = $this->db->execute($sql, $this->getValues());
@@ -705,7 +711,7 @@ class Table
     public function limit($value)
     {
         if (! is_null($value)) {
-            $this->sqlLimit = ' LIMIT '.(int) $value;
+            $this->sqlLimit = $value;
         }
 
         return $this;
@@ -721,7 +727,7 @@ class Table
     public function offset($value)
     {
         if (! is_null($value)) {
-            $this->sqlOffset = ' OFFSET '.(int) $value;
+            $this->sqlOffset = $value;
         }
 
         return $this;
@@ -820,7 +826,7 @@ class Table
         $this->groupBy = $this->db->escapeIdentifierList($this->groupBy);
 
         return trim(sprintf(
-            'SELECT %s FROM %s %s %s %s %s %s %s %s',
+            'SELECT %s FROM %s %s %s %s %s %s %s',
             $this->sqlSelect,
             $this->db->escapeIdentifier($this->name),
             implode(' ', $this->joins),
@@ -828,8 +834,10 @@ class Table
             empty($this->groupBy) ? '' : 'GROUP BY '.implode(', ', $this->groupBy),
             $this->aggregatedConditionBuilder->build(),
             $this->sqlOrder,
-            $this->sqlLimit,
-            $this->sqlOffset
+            $this->db->getDriver()->getLimitClause(
+                $this->sqlLimit,
+                $this->sqlOffset
+            )
         ));
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -91,14 +91,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
     public function testLimit()
     {
-        $this->assertEquals('SELECT * FROM `test`       LIMIT 10', $this->db->table('test')->limit(10)->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`       FETCH NEXT 10 ROWS', $this->db->table('test')->limit(10)->buildSelectQuery());
         $this->assertEquals('SELECT * FROM `test`', $this->db->table('test')->limit(null)->buildSelectQuery());
     }
 
     public function testOffset()
     {
-        $this->assertEquals('SELECT * FROM `test`        OFFSET 0', $this->db->table('test')->offset(0)->buildSelectQuery());
-        $this->assertEquals('SELECT * FROM `test`        OFFSET 10', $this->db->table('test')->offset(10)->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`        OFFSET 0 ROWS', $this->db->table('test')->offset(0)->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`        OFFSET 10 ROWS', $this->db->table('test')->offset(10)->buildSelectQuery());
         $this->assertEquals('SELECT * FROM `test`', $this->db->table('test')->limit(null)->buildSelectQuery());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -91,14 +91,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
 
     public function testLimit()
     {
-        $this->assertEquals('SELECT * FROM `test`       FETCH NEXT 10 ROWS', $this->db->table('test')->limit(10)->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`       LIMIT 10', $this->db->table('test')->limit(10)->buildSelectQuery());
         $this->assertEquals('SELECT * FROM `test`', $this->db->table('test')->limit(null)->buildSelectQuery());
     }
 
     public function testOffset()
     {
-        $this->assertEquals('SELECT * FROM `test`        OFFSET 0 ROWS', $this->db->table('test')->offset(0)->buildSelectQuery());
-        $this->assertEquals('SELECT * FROM `test`        OFFSET 10 ROWS', $this->db->table('test')->offset(10)->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`        OFFSET 0', $this->db->table('test')->offset(0)->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`        OFFSET 10', $this->db->table('test')->offset(10)->buildSelectQuery());
         $this->assertEquals('SELECT * FROM `test`', $this->db->table('test')->limit(null)->buildSelectQuery());
     }
 


### PR DESCRIPTION
This PR extends SELECT query SQL generation for MSSQL so that the correct syntax is used when a query is built with the 
`->limit()` or `->offset()` methods. Standard SQL does not work and clause of the form `OFFSET n ROWS FETCH NEXT n ROWS ONLY` must be used instead.

Because these clauses were being generated directly in the `Table` class when the corresponding methods are called, the responsibility has been extract into `Driver/Base::getLimitClause()`. A default implementation exists here, mirroring the existing functionality for all drivers, and a special implementation has been added via an override in `Driver/Mssql`.

Closes #24.