### PR TITLE
Correct CREATE TABLE IF NOT EXISTS syntax for MSSQL

### DIFF
--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -135,7 +135,7 @@ class Mssql extends Base
      */
     public function getSchemaVersion()
     {
-        $this->pdo->exec("IF (SELECT [object_id] FROM [sys].[tables] WHERE [object_id] = OBJECT_ID('".$this->schemaTable."')) IS NULL CREATE TABLE [".$this->schemaTable."] ([version] INT DEFAULT '0')");
+        $this->pdo->exec("IF (OBJECT_ID('".$this->schemaTable."')) IS NULL CREATE TABLE [".$this->schemaTable."] ([version] INT DEFAULT '0')");
 
         $rq = $this->pdo->prepare('SELECT [version] FROM ['.$this->schemaTable.']');
         $rq->execute();

--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -135,7 +135,7 @@ class Mssql extends Base
      */
     public function getSchemaVersion()
     {
-        $this->pdo->exec("CREATE TABLE IF NOT EXISTS [".$this->schemaTable."] ([version] INT DEFAULT '0')");
+        $this->pdo->exec("IF (SELECT [object_id] FROM [sys].[tables] WHERE [object_id] = OBJECT_ID('".$this->schemaTable."')) IS NULL CREATE TABLE [".$this->schemaTable."] ([version] INT DEFAULT '0')");
 
         $rq = $this->pdo->prepare('SELECT [version] FROM ['.$this->schemaTable.']');
         $rq->execute();


### PR DESCRIPTION
This pull request fixes changes the syntax present in the Mssql driver's `getSchemaVersion()` function to be acceptable T-SQL syntax.

T-SQL does not support the `CREATE TABLE IF EXISTS` syntax so the `OBJECT_ID` function must be used instead to check if such database object exists.

There were two commits made in this pull request, the first being a bit longer, but guarantees that the ID returned by `OBJECT_ID` is a table and not another database object such as a view or function.

One thing to keep in mind though is that the provided fix **only works for tables in the default `dbo` database schema**. Tables that are in another schema will need to have their schema specified. For example, the schema in the snippet below is prepended before the table name, spearated by a period:
```sql
IF (OBJECT_ID('OtherSchema.TableName')) IS NULL
    CREATE TABLE [TableName] ([version] INT DEFAULT '0')
```
