### PR TITLE
[ENHANCEMENT] - Implement NOT and XOR operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ $db->table('mytable')
     ->findAll();
 ```
 
-How to make a OR condition:
+How to make an OR condition:
 
 ```php
 $db->table('mytable')
@@ -462,7 +462,31 @@ $db->table('mytable')
     ->findAll();
 ```
 
-Further AND conditions can be embedded within an OR:
+How to make an XOR condition:
+
+```php
+$db->table('mytable')
+    ->beginXor()
+    ->like('column2', '%mytable')
+    ->gte('column1', 3)
+    ->closeXor()
+    ->eq('column5', 'titi')
+    ->findAll();
+```
+
+How to make a NOT condition:
+
+```php
+$db->table('mytable')
+    ->beginNot()
+    ->like('column2', '%mytable')
+    ->gte('column1', 3)
+    ->closeNot()
+    ->eq('column5', 'titi')
+    ->findAll();
+```
+
+Logical conditions can be embedded within other logical conditions:
 
 ```php
 $db->table('mytable')

--- a/lib/PicoDb/Builder/BaseConditionBuilder.php
+++ b/lib/PicoDb/Builder/BaseConditionBuilder.php
@@ -38,7 +38,7 @@ class BaseConditionBuilder
     protected $conditions = array();
 
     /**
-     * SQL embedded AND/OR conditions
+     * SQL embedded NOT/AND/OR/XOR conditions
      *
      * @access private
      * @var    LogicConditionBuilder[]
@@ -102,6 +102,24 @@ class BaseConditionBuilder
         }
     }
 
+    public function beginNot()
+    {
+        $this->embeddedConditionOffset++;
+        $this->embeddedConditions[$this->embeddedConditionOffset] = new LogicConditionBuilder('NOT');
+    }
+
+    public function closeNot()
+    {
+        $condition = $this->embeddedConditions[$this->embeddedConditionOffset]->build();
+        $this->embeddedConditionOffset--;
+
+        if ($this->embeddedConditionOffset > 0) {
+            $this->embeddedConditions[$this->embeddedConditionOffset]->withCondition($condition);
+        } else {
+            $this->conditions[] = $condition;
+        }
+    }
+
     /**
      * Start AND condition
      *
@@ -147,6 +165,34 @@ class BaseConditionBuilder
      * @access public
      */
     public function closeOr()
+    {
+        $condition = $this->embeddedConditions[$this->embeddedConditionOffset]->build();
+        $this->embeddedConditionOffset--;
+
+        if ($this->embeddedConditionOffset > 0) {
+            $this->embeddedConditions[$this->embeddedConditionOffset]->withCondition($condition);
+        } else {
+            $this->conditions[] = $condition;
+        }
+    }
+
+    /**
+     * Start OR condition
+     *
+     * @access public
+     */
+    public function beginXor()
+    {
+        $this->embeddedConditionOffset++;
+        $this->embeddedConditions[$this->embeddedConditionOffset] = new LogicConditionBuilder('XOR');
+    }
+
+    /**
+     * Close OR condition
+     *
+     * @access public
+     */
+    public function closeXor()
     {
         $condition = $this->embeddedConditions[$this->embeddedConditionOffset]->build();
         $this->embeddedConditionOffset--;

--- a/lib/PicoDb/Builder/LogicConditionBuilder.php
+++ b/lib/PicoDb/Builder/LogicConditionBuilder.php
@@ -53,6 +53,14 @@ class LogicConditionBuilder implements BuilderInterface
      */
     public function build()
     {
+        if ($this->type === 'NOT') {
+            if (count($this->conditions) === 1) {
+                return 'NOT ' . $this->conditions[0];
+            }
+
+            return 'NOT (' . implode(' AND ', $this->conditions) . ')';
+        }
+
         return '('.implode(' '. $this->type .' ', $this->conditions).')';
     }
 }

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -16,10 +16,14 @@ use PicoDb\Builder\UpdateBuilder;
  * @author  Frederic Guillot
  *
  * @method   $this   addCondition($sql)
+ * @method   $this   beginNot()
+ * @method   $this   closeNot()
  * @method   $this   beginAnd()
  * @method   $this   closeAnd()
  * @method   $this   beginOr()
  * @method   $this   closeOr()
+ * @method   $this   beginXor()
+ * @method   $this   closeXor()
  * @method   $this   eq($column, $value)
  * @method   $this   neq($column, $value)
  * @method   $this   in($column, array $values)

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -327,7 +327,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` IS NOT NULL OR `b` = ?)', $table->beginNot()->notNull('a')->orEq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -323,6 +323,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(4), $table->getConditionBuilder()->getValues());
     }
 
+    public function testNotConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` IS NOT NULL OR `b` = ?)', $table->beginNot()->notNull('a')->orEq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+    }
+
     public function testAndConditions()
     {
         $table = $this->db->table('test');
@@ -336,6 +344,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM `test`   WHERE `a` IS NOT NULL AND (`b` = ? OR `c` >= ?)', $table->notNull('a')->beginOr()->eq('b', 2)->gte('c', 5)->closeOr()->buildSelectQuery());
+        $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testXorConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` IS NOT NULL AND (`b` = ? XOR `c` >= ?)', $table->notNull('a')->beginXor()->eq('b', 2)->gte('c', 5)->closeXor()->buildSelectQuery());
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -327,7 +327,15 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testNotEmbeddedConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -328,7 +328,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testNotEmbeddedConditions()
@@ -336,7 +336,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -326,16 +326,16 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testNotEmbeddedConditions()
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -326,7 +326,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
         $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
@@ -334,7 +334,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -326,8 +326,8 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 2)->eq('b', 4)->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2, 4), $table->getConditionBuilder()->getValues());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -326,7 +326,15 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testNotEmbeddedConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -322,6 +322,14 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(4), $table->getConditionBuilder()->getValues());
     }
 
+    public function testNotConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 2)->eq('b', 4)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2, 4), $table->getConditionBuilder()->getValues());
+    }
+
     public function testAndConditions()
     {
         $table = $this->db->table('test');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -373,7 +373,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testNotEmbeddedConditions()
@@ -381,7 +381,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -372,7 +372,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 
@@ -380,7 +380,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -368,6 +368,13 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(4), $table->getConditionBuilder()->getValues());
     }
 
+    public function testNotConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" IS NOT NULL)', $table->beginNot()->notNull('a')->closeNot()->buildSelectQuery());
+    }
+
     public function testAndConditions()
     {
         $table = $this->db->table('test');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -372,7 +372,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 
@@ -380,7 +380,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -372,7 +372,8 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" IS NOT NULL)', $table->beginNot()->notNull('a')->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -372,7 +372,15 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testNotEmbeddedConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 


### PR DESCRIPTION
This PR extends the condition builder to support `beginNot/closeNot` and `beginXor/closeXor` methods.

Note that `XOR` is only available as an operator when the MySQL is in use. Calling the method will still generate unsupported SQL.