### PR TITLE
[ENHANCEMENT] - Allow additional conditions on joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Returns true if a record exists otherwise false.
 $db->table('mytable')->eq('column1', 12)->exists();
 ```
 
-### Left joins
+### Joins
 
 ```php
 // SELECT * FROM mytable LEFT JOIN my_other_table AS t1 ON t1.id=mytable.foreign_key
@@ -345,6 +345,28 @@ or
 // SELECT * FROM mytable LEFT JOIN my_other_table ON my_other_table.id=mytable.foreign_key
 $db->table('mytable')->join('my_other_table', 'id', 'foreign_key')->findAll();
 ```
+
+or
+
+```php
+// SELECT * FROM mytable LEFT JOIN my_other_table AS t1 ON t1.id=mytable.foreign_key
+$db->table('mytable')->inner('my_other_table', 't1', 'id', 'mytable', 'foreign_key')->findAll();
+```
+
+Additional equality conditions can be added to a left or inner join:
+
+```php
+// SELECT * FROM mytable LEFT JOIN my_other_table AS t1 ON t1.id=mytable.foreign_key and t1.status="active"
+$db->table('mytable')->left('my_other_table', 't1', 'id', 'mytable', 'foreign_key', ['status' => 'active'])->findAll();
+```
+
+or
+
+```php
+// SELECT * FROM mytable LEFT JOIN my_other_table AS t1 ON t1.id=mytable.foreign_key and t1.status IN ("archived", "disabled")
+$db->table('mytable')->left('my_other_table', 't1', 'id', 'mytable', 'foreign_key', ['status' => ['archived', 'disabled']])->findAll();
+```
+
 
 ### Equals condition
 

--- a/lib/PicoDb/Builder/BaseConditionBuilder.php
+++ b/lib/PicoDb/Builder/BaseConditionBuilder.php
@@ -38,7 +38,7 @@ class BaseConditionBuilder
     protected $conditions = array();
 
     /**
-     * SQL embedded AND/OR conditions
+     * SQL embedded NOT/AND/OR/XOR conditions
      *
      * @access private
      * @var    LogicConditionBuilder[]
@@ -102,6 +102,24 @@ class BaseConditionBuilder
         }
     }
 
+    public function beginNot()
+    {
+        $this->embeddedConditionOffset++;
+        $this->embeddedConditions[$this->embeddedConditionOffset] = new LogicConditionBuilder('NOT');
+    }
+
+    public function closeNot()
+    {
+        $condition = $this->embeddedConditions[$this->embeddedConditionOffset]->build();
+        $this->embeddedConditionOffset--;
+
+        if ($this->embeddedConditionOffset > 0) {
+            $this->embeddedConditions[$this->embeddedConditionOffset]->withCondition($condition);
+        } else {
+            $this->conditions[] = $condition;
+        }
+    }
+
     /**
      * Start AND condition
      *
@@ -147,6 +165,34 @@ class BaseConditionBuilder
      * @access public
      */
     public function closeOr()
+    {
+        $condition = $this->embeddedConditions[$this->embeddedConditionOffset]->build();
+        $this->embeddedConditionOffset--;
+
+        if ($this->embeddedConditionOffset > 0) {
+            $this->embeddedConditions[$this->embeddedConditionOffset]->withCondition($condition);
+        } else {
+            $this->conditions[] = $condition;
+        }
+    }
+
+    /**
+     * Start OR condition
+     *
+     * @access public
+     */
+    public function beginXor()
+    {
+        $this->embeddedConditionOffset++;
+        $this->embeddedConditions[$this->embeddedConditionOffset] = new LogicConditionBuilder('XOR');
+    }
+
+    /**
+     * Close OR condition
+     *
+     * @access public
+     */
+    public function closeXor()
     {
         $condition = $this->embeddedConditions[$this->embeddedConditionOffset]->build();
         $this->embeddedConditionOffset--;

--- a/lib/PicoDb/Builder/LogicConditionBuilder.php
+++ b/lib/PicoDb/Builder/LogicConditionBuilder.php
@@ -53,6 +53,14 @@ class LogicConditionBuilder implements BuilderInterface
      */
     public function build()
     {
+        if ($this->type === 'NOT') {
+            if (count($this->conditions) === 1) {
+                return 'NOT ' . $this->conditions[0];
+            }
+
+            return 'NOT (' . implode(' AND ', $this->conditions) . ')';
+        }
+
         return '('.implode(' '. $this->type .' ', $this->conditions).')';
     }
 }

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -16,10 +16,14 @@ use PicoDb\Builder\UpdateBuilder;
  * @author  Frederic Guillot
  *
  * @method   $this   addCondition($sql)
+ * @method   $this   beginNot()
+ * @method   $this   closeNot()
  * @method   $this   beginAnd()
  * @method   $this   closeAnd()
  * @method   $this   beginOr()
  * @method   $this   closeOr()
+ * @method   $this   beginXor()
+ * @method   $this   closeXor()
  * @method   $this   eq($column, $value)
  * @method   $this   neq($column, $value)
  * @method   $this   in($column, array $values)

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -571,8 +571,8 @@ class Table
                 $this->joinValues = array_merge($this->joinValues, $value);
             } else {
                 $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' = ?';
+                $this->joinValues[] = $value;
             }
-            $this->joinValues[] = $value;
         }
 
         $this->joins[] = sprintf(
@@ -608,8 +608,8 @@ class Table
                 $this->joinValues = array_merge($this->joinValues, $value);
             } else {
                 $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' = ?';
+                $this->joinValues[] = $value;
             }
-            $this->joinValues[] = $value;
         }
 
         $this->joins[] = sprintf(

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -559,16 +559,24 @@ class Table
      * @param  string   $column1
      * @param  string   $table2
      * @param  string   $column2
+     * @param  array    $conditions
      * @return $this
      */
-    public function left($table1, $alias1, $column1, $table2, $column2)
+    public function left($table1, $alias1, $column1, $table2, $column2, $conditions = [])
     {
+        $where = '';
+        foreach ($conditions as $column => $value) {
+            $where .= ' AND '.$this->db->escapeIdentifier($alias1).'.'.$this->db->escapeIdentifier($column).' = ?';
+            $this->joinValues[] = $value;
+        }
+
         $this->joins[] = sprintf(
-            'LEFT JOIN %s AS %s ON %s=%s',
+            'LEFT JOIN %s AS %s ON %s=%s%s',
             $this->db->escapeIdentifier($table1),
             $this->db->escapeIdentifier($alias1),
             $this->db->escapeIdentifier($alias1).'.'.$this->db->escapeIdentifier($column1),
-            $this->db->escapeIdentifier($table2).'.'.$this->db->escapeIdentifier($column2)
+            $this->db->escapeIdentifier($table2).'.'.$this->db->escapeIdentifier($column2),
+            $where
         );
 
         return $this;
@@ -583,16 +591,24 @@ class Table
      * @param  string   $column1
      * @param  string   $table2
      * @param  string   $column2
+     * @param  array    $conditions
      * @return $this
      */
-    public function inner($table1, $alias1, $column1, $table2, $column2)
+    public function inner($table1, $alias1, $column1, $table2, $column2, array $conditions = [])
     {
+        $where = '';
+        foreach ($conditions as $column => $value) {
+            $where .= ' AND '.$this->db->escapeIdentifier($alias1).'.'.$this->db->escapeIdentifier($column).' = ?';
+            $this->joinValues[] = $value;
+        }
+
         $this->joins[] = sprintf(
-            'JOIN %s AS %s ON %s=%s',
+            'JOIN %s AS %s ON %s=%s%s',
             $this->db->escapeIdentifier($table1),
             $this->db->escapeIdentifier($alias1),
             $this->db->escapeIdentifier($alias1).'.'.$this->db->escapeIdentifier($column1),
-            $this->db->escapeIdentifier($table2).'.'.$this->db->escapeIdentifier($column2)
+            $this->db->escapeIdentifier($table2).'.'.$this->db->escapeIdentifier($column2),
+            $where
         );
 
         return $this;

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -566,7 +566,12 @@ class Table
     {
         $where = '';
         foreach ($conditions as $column => $value) {
-            $where .= ' AND '.$this->db->escapeIdentifier($alias1).'.'.$this->db->escapeIdentifier($column).' = ?';
+            if (is_array($value)) {
+                $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' IN (' . implode(',', array_fill(0, count($value), '?')) . ')';
+                $this->joinValues = array_merge($this->joinValues, $value);
+            } else {
+                $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' = ?';
+            }
             $this->joinValues[] = $value;
         }
 
@@ -598,7 +603,12 @@ class Table
     {
         $where = '';
         foreach ($conditions as $column => $value) {
-            $where .= ' AND '.$this->db->escapeIdentifier($alias1).'.'.$this->db->escapeIdentifier($column).' = ?';
+            if (is_array($value)) {
+                $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' IN (' . implode(',', array_fill(0, count($value), '?')) . ')';
+                $this->joinValues = array_merge($this->joinValues, $value);
+            } else {
+                $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' = ?';
+            }
             $this->joinValues[] = $value;
         }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -508,6 +508,24 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testLeftJoinConditions()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER NOT NULL, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
+        );
+
+        $this->assertNull(
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
+        );
+    }
+
     public function testJoinSubquery()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -327,7 +327,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` IS NOT NULL OR `b` = ?)', $table->beginNot()->notNull('a')->orEq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -521,6 +521,12 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
             $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
         );
 
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => [18, 19]])->findOne()
+        );
+
+
         $this->assertNull(
             $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
         );

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -323,6 +323,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(4), $table->getConditionBuilder()->getValues());
     }
 
+    public function testNotConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` IS NOT NULL OR `b` = ?)', $table->beginNot()->notNull('a')->orEq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+    }
+
     public function testAndConditions()
     {
         $table = $this->db->table('test');
@@ -336,6 +344,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM `test`   WHERE `a` IS NOT NULL AND (`b` = ? OR `c` >= ?)', $table->notNull('a')->beginOr()->eq('b', 2)->gte('c', 5)->closeOr()->buildSelectQuery());
+        $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testXorConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` IS NOT NULL AND (`b` = ? XOR `c` >= ?)', $table->notNull('a')->beginXor()->eq('b', 2)->gte('c', 5)->closeXor()->buildSelectQuery());
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -327,7 +327,15 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testNotEmbeddedConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -328,7 +328,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testNotEmbeddedConditions()
@@ -336,7 +336,7 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -326,16 +326,16 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testNotEmbeddedConditions()
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -326,7 +326,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
         $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
@@ -334,7 +334,7 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -512,6 +512,11 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
             $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
         );
 
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => [18, 19]])->findOne()
+        );
+
         $this->assertNull(
             $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
         );

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -326,8 +326,8 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 2)->eq('b', 4)->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2, 4), $table->getConditionBuilder()->getValues());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -326,7 +326,15 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testNotEmbeddedConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -499,6 +499,24 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testLeftJoinConditions()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER NOT NULL, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
+        );
+
+        $this->assertNull(
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
+        );
+    }
+
     public function testJoinSubquery()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -322,6 +322,14 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(4), $table->getConditionBuilder()->getValues());
     }
 
+    public function testNotConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 2)->eq('b', 4)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2, 4), $table->getConditionBuilder()->getValues());
+    }
+
     public function testAndConditions()
     {
         $table = $this->db->table('test');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -587,6 +587,24 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testLeftJoinConditions()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER NOT NULL, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
+        );
+
+        $this->assertNull(
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
+        );
+    }
+
     public function testJoinSubquery()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -373,7 +373,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testNotEmbeddedConditions()
@@ -381,7 +381,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $table = $this->db->table('test');
 
         $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
-        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -372,7 +372,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 
@@ -380,7 +380,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -600,6 +600,11 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
             $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
         );
 
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => [18, 19]])->findOne()
+        );
+
         $this->assertNull(
             $this->db->table('test2')->columns('a', 'b')->eq('a', 18)->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
         );

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -368,6 +368,13 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(4), $table->getConditionBuilder()->getValues());
     }
 
+    public function testNotConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" IS NOT NULL)', $table->beginNot()->notNull('a')->closeNot()->buildSelectQuery());
+    }
+
     public function testAndConditions()
     {
         $table = $this->db->table('test');

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -372,7 +372,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 
@@ -380,7 +380,7 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? OR "b" = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -372,7 +372,8 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" IS NOT NULL)', $table->beginNot()->notNull('a')->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 
     public function testAndConditions()

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -372,7 +372,15 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? AND `b` = ?)', $table->beginNot()->eq('a', 1)->eq('b', 2)->closeNot()->buildSelectQuery());
+        $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testNotEmbeddedConditions()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE NOT (`a` = ? OR `b` = ?)', $table->beginNot()->beginOr()->eq('a', 1)->eq('b', 2)->closeOr()->closeNot()->buildSelectQuery());
         $this->assertEquals(array(2), $table->getConditionBuilder()->getValues());
     }
 


### PR DESCRIPTION
This PR extends the `Table::left()` and `Table::inner()` methods with an optional parameter for specifying additional conditions on the join. While the existing parameters allow one table to be joined to another by matching columns, the new `$conditions` array specifies column => value mapping for the joined table.

**Example**
```php
$db
  ->table('foo')
  ->left('bar', 'b', 'foo_id', 'foo', 'id', ['baz' => 'test'])
  ->buildSelectQuery();
```
```sql
SELECT * FROM foo LEFT JOIN bar b ON b.foo_id = foo.id AND b.baz = "test"
```

