### PR TITLE
[HOTFIX] - Include bound parameters for joins within subqueries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -646,8 +646,7 @@ class Table
 
         $this->joinValues = array_merge(
             $this->joinValues,
-            $subQuery->getConditionBuilder()->getValues(),
-            $subQuery->getAggregatedConditionBuilder()->getValues()
+            $subQuery->getValues()
         );
 
         return $this;
@@ -675,8 +674,7 @@ class Table
 
         $this->joinValues = array_merge(
             $this->joinValues,
-            $subQuery->getConditionBuilder()->getValues(),
-            $subQuery->getAggregatedConditionBuilder()->getValues()
+            $subQuery->getValues()
         );
 
         return $this;


### PR DESCRIPTION
This PR fixes a bug where bound parameters for JOINs within subqueries are not included in final list of bound parameters when executing a query. The fix works by making use of the subquery's `getValues()` method (which collects _all_ bound parameter values) instead of manually constructing the list without values for JOINs.