### PR TITLE
Add `when` method to allow conditional query construction

### DIFF
--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -892,6 +892,21 @@ class Table
     }
 
     /**
+     * Executes the provided callback if the condition is true
+     *
+     * @param  bool    $condition
+     * @param  Closure $callback
+     * @return $this
+     */
+    public function when(bool $condition, Closure $callback)
+    {
+        if ($condition) {
+            $callback($this);
+        }
+        return $this;
+    }
+
+    /**
      * Magic method for sql conditions
      *
      * @access public

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -893,6 +893,7 @@ class Table
 
     /**
      * Executes the provided callback if the condition is true
+     * Otherwise, executes the default callback, if provided
      *
      * @param bool         $condition
      * @param Closure      $callback

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -894,14 +894,17 @@ class Table
     /**
      * Executes the provided callback if the condition is true
      *
-     * @param  bool    $condition
-     * @param  Closure $callback
+     * @param bool         $condition
+     * @param Closure      $callback
+     * @param Closure|null $default
      * @return $this
      */
-    public function when(bool $condition, Closure $callback)
+    public function when(bool $condition, Closure $callback, ?Closure $default = null)
     {
         if ($condition) {
             $callback($this);
+        } elseif ($default) {
+            $default($this);
         }
         return $this;
     }


### PR DESCRIPTION
This idea is lifted from laravel: https://laravel.com/docs/12.x/queries#conditional-clauses

```php
$q = $db->table('users');

if ($excludeArchived) {
    $q->isNull('archived_at');
}

$users = $q->findAll();
```
--- VS ---
```php
$users = $db->table('users')
    ->when($excludeArchived, fn ($q) => $q->isNull('archived_at'))
    ->findAll();
```

The above is a very basic example, so doesn't truly demonstrate the usefulness, but imagine many conditionals and managing all those if/else structures.

There's also a default fallback argument.

```php
$users = $db->table('users')
    ->when(
        $findDeletedUsers,
        fn ($q) => $q->notNull('deleted_at'),
        fn ($q) => $q->isNull('deleted_at')
    )
    ->findAll();
```
