### PR TITLE
Return no results, rather than throwing an exception when ->in() is passed an empty array.

### DIFF
--- a/lib/PicoDb/Builder/BaseConditionBuilder.php
+++ b/lib/PicoDb/Builder/BaseConditionBuilder.php
@@ -243,7 +243,7 @@ class BaseConditionBuilder
             $this->addCondition($this->db->escapeIdentifier($column).' IN ('.implode(', ', array_fill(0, count($values), '?')).')');
             $this->values = array_merge($this->values, $values);
         } else {
-            throw new \InvalidArgumentException('$values must not be an empty array');
+            $this->addCondition('0 = 1');
         }
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -137,9 +137,10 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('SELECT * FROM `test`   WHERE `a` IN (?, ?)', $table->in('a', array('b', 'c'))->buildSelectQuery());
         $this->assertEquals(array('b', 'c'), $table->getConditionBuilder()->getValues());
 
-        $this->expectException(\InvalidArgumentException::class);
         $table = $this->db->table('test');
-        $table->in('a', array());
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE 0 = 1', $table->in('a', array())->buildSelectQuery());
+        $this->assertEquals(array(), $table->getConditionBuilder()->getValues());
     }
 
     public function testConditionInSubquery()

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -135,9 +135,10 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" IN (?, ?)', $table->in('a', array('b', 'c'))->buildSelectQuery());
         $this->assertEquals(array('b', 'c'), $table->getConditionBuilder()->getValues());
 
-        $this->expectException(\InvalidArgumentException::class);
         $table = $this->db->table('test');
-        $table->in('a', array());
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE 0 = 1', $table->in('a', array())->buildSelectQuery());
+        $this->assertEquals(array(), $table->getConditionBuilder()->getValues());
     }
 
     public function testConditionInSubquery()

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -129,10 +129,11 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals('SELECT * FROM "test"   WHERE "a" IN (?, ?)', $table->in('a', array('b', 'c'))->buildSelectQuery());
         $this->assertEquals(array('b', 'c'), $table->getConditionBuilder()->getValues());
-
-        $this->expectException(\InvalidArgumentException::class);
+        
         $table = $this->db->table('test');
-        $table->in('a', array());
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE 0 = 1', $table->in('a', array())->buildSelectQuery());
+        $this->assertEquals(array(), $table->getConditionBuilder()->getValues());
     }
 
     public function testConditionInSubquery()


### PR DESCRIPTION
There is some precedent for this in other DBALs. [Laravel does this](https://github.com/illuminate/database/blob/08157f0cffa6c42f41ad72ddb1fca61fb1f67945/Query/Grammars/Grammar.php#L343).

To me it does seem like a saner approach to just return no results rather than throw an exception.