### PR TITLE
Ensured parametrised queries respect data types

### DIFF
--- a/lib/PicoDb/StatementHandler.php
+++ b/lib/PicoDb/StatementHandler.php
@@ -279,12 +279,36 @@ class StatementHandler
         }
 
         foreach ($this->positionalParams as $value) {
-            $pdoStatement->bindValue($i, $value, PDO::PARAM_STR);
+            switch (true) {
+                case is_numeric($value):
+                    $pdoStatement->bindValue($i, $value, PDO::PARAM_INT);
+                    break;
+                case is_bool($value):
+                    $pdoStatement->bindValue($i, $value, PDO::PARAM_BOOL);
+                    break;
+                case $value === null:
+                    $pdoStatement->bindValue($i, $value, PDO::PARAM_NULL);
+                    break;
+                default:
+                    $pdoStatement->bindValue($i, $value, PDO::PARAM_STR);
+            }
             $i++;
         }
 
         foreach ($this->namedParams as $name => $value) {
-            $pdoStatement->bindValue($name, $value, PDO::PARAM_STR);
+            switch (true) {
+                case is_numeric($value):
+                    $pdoStatement->bindValue($name, $value, PDO::PARAM_INT);
+                    break;
+                case is_bool($value):
+                    $pdoStatement->bindValue($name, $value, PDO::PARAM_BOOL);
+                    break;
+                case $value === null:
+                    $pdoStatement->bindValue($i, $value, PDO::PARAM_NULL);
+                    break;
+                default:
+                    $pdoStatement->bindValue($name, $value, PDO::PARAM_STR);
+            }
         }
     }
 

--- a/lib/PicoDb/StatementHandler.php
+++ b/lib/PicoDb/StatementHandler.php
@@ -280,7 +280,7 @@ class StatementHandler
 
         foreach ($this->positionalParams as $value) {
             switch (true) {
-                case is_numeric($value):
+                case is_int($value):
                     $pdoStatement->bindValue($i, $value, PDO::PARAM_INT);
                     break;
                 case is_bool($value):
@@ -297,7 +297,7 @@ class StatementHandler
 
         foreach ($this->namedParams as $name => $value) {
             switch (true) {
-                case is_numeric($value):
+                case is_int($value):
                     $pdoStatement->bindValue($name, $value, PDO::PARAM_INT);
                     break;
                 case is_bool($value):

--- a/lib/PicoDb/StatementHandler.php
+++ b/lib/PicoDb/StatementHandler.php
@@ -304,7 +304,7 @@ class StatementHandler
                     $pdoStatement->bindValue($name, $value, PDO::PARAM_BOOL);
                     break;
                 case $value === null:
-                    $pdoStatement->bindValue($i, $value, PDO::PARAM_NULL);
+                    $pdoStatement->bindValue($name, $value, PDO::PARAM_NULL);
                     break;
                 default:
                     $pdoStatement->bindValue($name, $value, PDO::PARAM_STR);


### PR DESCRIPTION
If using `Database::execute()` with an array of values of varying types, particularly booleans or ints, they are encased in quotes, causing them to be interpreted as strings.
This would result in the following error:
`SQL Error: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'BoolVal' at row 1 (0)`

This was found by attempting to call a stored procedure that took a `bit` as a parameter, in which the boolean in PHP was passed as a string, violating the max length of the parameter.

Below is some sample code I used to replicate the issue before the fix:

MySQL Stored Procedure:
```sql
DELIMITER $$
$$
CREATE PROCEDURE DEBUG(
	IN String nvarchar(128),
	IN Nullable varchar(32),
	IN NumberVal INT,
	IN BoolVal bit)
BEGIN
	SELECT String, Nullable, NumberVal, BoolVal;
END
$$
DELIMITER ;
```
PHP Code:
```php
<?php
$data['String'] = 'hello';
$data['Nullable'] = null;
$data['NumberVal'] = 21;
$data['BoolVal'] = true; // This causes an error when executed.

db->execute("CALL DEBUG(?,?,?,?)", array_values($data));
```
**Note:** I could not test for the same erroneous behaviour using named parameters, as I believe MySQL does not support them in stored procedures. I included the fix in that `foreach` loop anyway as it looks like it would encounter the same issue if used.