### PR TITLE
Add trust server certificate option for MSSQL connections

### DIFF
--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -46,6 +46,9 @@ class Mssql extends Base
         if (! empty($settings['port'])) {
             $dsn .= ';port=' . $settings['port'];
         }
+        if (! empty($settings['trust_server_cert'])) {
+            $dsn .= ';TrustServerCertificate=' . $settings['trust_server_cert'];
+        }
 
         $this->pdo = new PDO($dsn, $settings['username'], $settings['password']);
 


### PR DESCRIPTION
Allows for connections to SQL Servers that require a trusted certificate to establish a connection.