### PR TITLE
Expose `inTransaction()` from the PDO connection.

### DIFF
--- a/lib/PicoDb/Database.php
+++ b/lib/PicoDb/Database.php
@@ -279,6 +279,17 @@ class Database
     }
 
     /**
+     * Checks if inside a transaction
+     *
+     * @access public
+     * @return bool
+     */
+    public function inTransaction()
+    {
+        return $this->getConnection()->inTransaction();
+    }
+
+    /**
      * Begin a transaction
      *
      * @access public
@@ -286,7 +297,7 @@ class Database
      */
     public function startTransaction()
     {
-        if (! $this->getConnection()->inTransaction()) {
+        if (! $this->inTransaction()) {
             return $this->getConnection()->beginTransaction();
         }
 
@@ -301,7 +312,7 @@ class Database
      */
     public function closeTransaction()
     {
-        if ($this->getConnection()->inTransaction()) {
+        if ($this->inTransaction()) {
             return $this->getConnection()->commit();
         }
 
@@ -316,7 +327,7 @@ class Database
      */
     public function cancelTransaction()
     {
-        if ($this->getConnection()->inTransaction()) {
+        if ($this->inTransaction()) {
             return $this->getConnection()->rollBack();
         }
 


### PR DESCRIPTION
Doing `$picoDB->getConnection()->inTransaction();` felt cumbersome. We may as well expose this functionality as a method. Especially since the other transaction methods are exposed.