### PR TITLE
Begin adding types, starting with $pdo on the Driver classes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "scripts": {
         "docker:start": "docker compose up --build -d",
         "docker:stop": "docker compose down",
-        "test": "docker compose run --rm php /app/vendor/bin/phpunit /app/tests"
+        "test": "docker compose run --rm php /app/vendor/bin/phpunit /app/tests",
+        "psalm": "vendor/bin/psalm"
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     links:
       - mysql
       - postgres
+      - sqlserver
     environment:
       - MYSQL_HOST=mysql
       - POSTGRES_HOST=postgres

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -25,10 +25,9 @@ abstract class Base
     /**
      * PDO connection
      *
-     * @access protected
-     * @var PDO
+     * @access private
      */
-    protected $pdo = null;
+    private ?PDO $pdo = null;
 
     /**
      * Create a new PDO connection
@@ -127,18 +126,32 @@ abstract class Base
         }
 
         $this->createConnection($settings);
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->getConnection()->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
 
     /**
      * Get the PDO connection
      *
      * @access public
-     * @return PDO
+     * @throws LogicException
      */
-    public function getConnection()
+    public function getConnection(): PDO
     {
+        if ($this->pdo === null) {
+            throw new LogicException('The database connection is not established.');
+        }
+
         return $this->pdo;
+    }
+
+    /**
+     * Set the PDO connection
+     *
+     * @access protected
+     */
+    protected function setConnection(PDO $pdo): void
+    {
+        $this->pdo = $pdo;
     }
 
     /**
@@ -187,29 +200,29 @@ abstract class Base
     public function upsert($table, $keyColumn, $valueColumn, array $dictionary)
     {
         try {
-            $this->pdo->beginTransaction();
+            $this->getConnection()->beginTransaction();
 
             foreach ($dictionary as $key => $value) {
 
-                $rq = $this->pdo->prepare('SELECT 1 FROM '.$this->escape($table).' WHERE '.$this->escape($keyColumn).'=?');
+                $rq = $this->getConnection()->prepare('SELECT 1 FROM '.$this->escape($table).' WHERE '.$this->escape($keyColumn).'=?');
                 $rq->execute(array($key));
 
                 if ($rq->fetchColumn()) {
-                    $rq = $this->pdo->prepare('UPDATE '.$this->escape($table).' SET '.$this->escape($valueColumn).'=? WHERE '.$this->escape($keyColumn).'=?');
+                    $rq = $this->getConnection()->prepare('UPDATE '.$this->escape($table).' SET '.$this->escape($valueColumn).'=? WHERE '.$this->escape($keyColumn).'=?');
                     $rq->execute(array($value, $key));
                 }
                 else {
-                    $rq = $this->pdo->prepare('INSERT INTO '.$this->escape($table).' ('.$this->escape($keyColumn).', '.$this->escape($valueColumn).') VALUES (?, ?)');
+                    $rq = $this->getConnection()->prepare('INSERT INTO '.$this->escape($table).' ('.$this->escape($keyColumn).', '.$this->escape($valueColumn).') VALUES (?, ?)');
                     $rq->execute(array($key, $value));
                 }
             }
 
-            $this->pdo->commit();
+            $this->getConnection()->commit();
 
             return true;
         }
         catch (PDOException $e) {
-            $this->pdo->rollBack();
+            $this->getConnection()->rollBack();
             return false;
         }
     }

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -18,9 +18,8 @@ abstract class Base
      * List of required settings options
      *
      * @access protected
-     * @var array
      */
-    protected $requiredAttributes = array();
+    protected array $requiredAttributes = array();
 
     /**
      * PDO connection

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -251,7 +251,11 @@ abstract class Base
     protected function getSqlFromPreparedStatement($sql, array $values)
     {
         foreach ($values as $value) {
-            $sql = substr_replace($sql, "'$value'", strpos($sql, '?'), 1);
+            $pos = strpos($sql, '?');
+            if ($pos === false) {
+                break;
+            }
+            $sql = substr_replace($sql, "'$value'", $pos, 1);
         }
 
         return $sql;

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -88,9 +88,8 @@ abstract class Base
      *
      * @abstract
      * @access public
-     * @return integer
      */
-    abstract public function getLastId();
+    abstract public function getLastId(): string|false;
 
     /**
      * Get current schema version

--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -121,9 +121,8 @@ class Mssql extends Base
      * Get last inserted id
      *
      * @access public
-     * @return integer
      */
-    public function getLastId()
+    public function getLastId(): string|false
     {
         return $this->getConnection()->lastInsertId();
     }

--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -16,22 +16,20 @@ class Mssql extends Base
      * List of required settings options
      *
      * @access protected
-     * @var array
      */
-    protected $requiredAttributes = array(
+    protected array $requiredAttributes = [
         'hostname',
         'username',
         'password',
         'database',
-    );
+    ];
 
     /**
      * Table to store the schema version
      *
      * @access private
-     * @var array
      */
-    private $schemaTable = 'schema_version';
+    private string $schemaTable = 'schema_version';
 
     /**
      * Create a new PDO connection

--- a/lib/PicoDb/Driver/Mssql.php
+++ b/lib/PicoDb/Driver/Mssql.php
@@ -50,7 +50,7 @@ class Mssql extends Base
             $dsn .= ';TrustServerCertificate=' . ($settings['trust_server_cert'] ? 'true' : 'false');
         }
 
-        $this->pdo = new PDO($dsn, $settings['username'], $settings['password']);
+        $this->setConnection(new PDO($dsn, $settings['username'], $settings['password']));
 
         if (isset($settings['schema_table'])) {
             $this->schemaTable = $settings['schema_table'];
@@ -64,7 +64,7 @@ class Mssql extends Base
      */
     public function enableForeignKeys()
     {
-        $this->pdo->exec('EXEC sp_MSforeachtable @command1="ALTER TABLE ? CHECK CONSTRAINT ALL"; GO;');
+        $this->getConnection()->exec('EXEC sp_MSforeachtable @command1="ALTER TABLE ? CHECK CONSTRAINT ALL"; GO;');
     }
 
     /**
@@ -74,7 +74,7 @@ class Mssql extends Base
      */
     public function disableForeignKeys()
     {
-        $this->pdo->exec('EXEC sp_MSforeachtable @command1="ALTER TABLE ? NOCHECK CONSTRAINT ALL"; GO;');
+        $this->getConnection()->exec('EXEC sp_MSforeachtable @command1="ALTER TABLE ? NOCHECK CONSTRAINT ALL"; GO;');
     }
 
     /**
@@ -127,7 +127,7 @@ class Mssql extends Base
      */
     public function getLastId()
     {
-        return $this->pdo->lastInsertId();
+        return $this->getConnection()->lastInsertId();
     }
 
     /**
@@ -138,9 +138,9 @@ class Mssql extends Base
      */
     public function getSchemaVersion()
     {
-        $this->pdo->exec("IF (OBJECT_ID('".$this->schemaTable."')) IS NULL CREATE TABLE [".$this->schemaTable."] ([version] INT DEFAULT '0')");
+        $this->getConnection()->exec("IF (OBJECT_ID('".$this->schemaTable."')) IS NULL CREATE TABLE [".$this->schemaTable."] ([version] INT DEFAULT '0')");
 
-        $rq = $this->pdo->prepare('SELECT [version] FROM ['.$this->schemaTable.']');
+        $rq = $this->getConnection()->prepare('SELECT [version] FROM ['.$this->schemaTable.']');
         $rq->execute();
         $result = $rq->fetchColumn();
 
@@ -148,7 +148,7 @@ class Mssql extends Base
             return (int) $result;
         }
         else {
-            $this->pdo->exec('INSERT INTO ['.$this->schemaTable.'] VALUES(0)');
+            $this->getConnection()->exec('INSERT INTO ['.$this->schemaTable.'] VALUES(0)');
         }
 
         return 0;
@@ -162,7 +162,7 @@ class Mssql extends Base
      */
     public function setSchemaVersion($version)
     {
-        $rq = $this->pdo->prepare('UPDATE ['.$this->schemaTable.'] SET [version]=?');
+        $rq = $this->getConnection()->prepare('UPDATE ['.$this->schemaTable.'] SET [version]=?');
         $rq->execute(array($version));
     }
 

--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -42,12 +42,12 @@ class Mysql extends Base
      */
     public function createConnection(array $settings)
     {
-        $this->pdo = new PDO(
+        $this->setConnection(new PDO(
             $this->buildDsn($settings),
             $settings['username'],
             $settings['password'],
             $this->buildOptions($settings)
-        );
+        ));
 
         if (isset($settings['schema_table'])) {
             $this->schemaTable = $settings['schema_table'];
@@ -124,7 +124,7 @@ class Mysql extends Base
      */
     public function enableForeignKeys()
     {
-        $this->pdo->exec('SET FOREIGN_KEY_CHECKS=1');
+        $this->getConnection()->exec('SET FOREIGN_KEY_CHECKS=1');
     }
 
     /**
@@ -134,7 +134,7 @@ class Mysql extends Base
      */
     public function disableForeignKeys()
     {
-        $this->pdo->exec('SET FOREIGN_KEY_CHECKS=0');
+        $this->getConnection()->exec('SET FOREIGN_KEY_CHECKS=0');
     }
 
     /**
@@ -188,7 +188,7 @@ class Mysql extends Base
      */
     public function getLastId()
     {
-        return $this->pdo->lastInsertId();
+        return $this->getConnection()->lastInsertId();
     }
 
     /**
@@ -199,9 +199,9 @@ class Mysql extends Base
      */
     public function getSchemaVersion()
     {
-        $this->pdo->exec("CREATE TABLE IF NOT EXISTS `".$this->schemaTable."` (`version` INT DEFAULT '0') ENGINE=InnoDB CHARSET=utf8");
+        $this->getConnection()->exec("CREATE TABLE IF NOT EXISTS `".$this->schemaTable."` (`version` INT DEFAULT '0') ENGINE=InnoDB CHARSET=utf8");
 
-        $rq = $this->pdo->prepare('SELECT `version` FROM `'.$this->schemaTable.'`');
+        $rq = $this->getConnection()->prepare('SELECT `version` FROM `'.$this->schemaTable.'`');
         $rq->execute();
         $result = $rq->fetchColumn();
 
@@ -209,7 +209,7 @@ class Mysql extends Base
             return (int) $result;
         }
         else {
-            $this->pdo->exec('INSERT INTO `'.$this->schemaTable.'` VALUES(0)');
+            $this->getConnection()->exec('INSERT INTO `'.$this->schemaTable.'` VALUES(0)');
         }
 
         return 0;
@@ -223,7 +223,7 @@ class Mysql extends Base
      */
     public function setSchemaVersion($version)
     {
-        $rq = $this->pdo->prepare('UPDATE `'.$this->schemaTable.'` SET `version`=?');
+        $rq = $this->getConnection()->prepare('UPDATE `'.$this->schemaTable.'` SET `version`=?');
         $rq->execute(array($version));
     }
 
@@ -256,7 +256,7 @@ class Mysql extends Base
                 $values[] = $value;
             }
 
-            $rq = $this->pdo->prepare($sql);
+            $rq = $this->getConnection()->prepare($sql);
             $rq->execute($values);
 
             return true;

--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -182,9 +182,8 @@ class Mysql extends Base
      * Get last inserted id
      *
      * @access public
-     * @return integer
      */
-    public function getLastId()
+    public function getLastId(): string|false
     {
         return $this->getConnection()->lastInsertId();
     }

--- a/lib/PicoDb/Driver/Mysql.php
+++ b/lib/PicoDb/Driver/Mysql.php
@@ -17,22 +17,20 @@ class Mysql extends Base
      * List of required settings options
      *
      * @access protected
-     * @var array
      */
-    protected $requiredAttributes = array(
+    protected array $requiredAttributes = [
         'hostname',
         'username',
         'password',
         'database',
-    );
+    ];
 
     /**
      * Table to store the schema version
      *
      * @access private
-     * @var array
      */
-    private $schemaTable = 'schema_version';
+    private string $schemaTable = 'schema_version';
 
     /**
      * Create a new PDO connection

--- a/lib/PicoDb/Driver/Postgres.php
+++ b/lib/PicoDb/Driver/Postgres.php
@@ -64,7 +64,7 @@ class Postgres extends Base
             $options[PDO::ATTR_TIMEOUT] = $settings['timeout'];
         }
 
-        $this->pdo = new PDO($dsn, $username, $password, $options);
+        $this->setConnection(new PDO($dsn, $username, $password, $options));
 
         if (isset($settings['schema_table'])) {
             $this->schemaTable = $settings['schema_table'];
@@ -141,7 +141,7 @@ class Postgres extends Base
     public function getLastId()
     {
         try {
-            $rq = $this->pdo->prepare('SELECT LASTVAL()');
+            $rq = $this->getConnection()->prepare('SELECT LASTVAL()');
             $rq->execute();
 
             return $rq->fetchColumn();
@@ -159,9 +159,9 @@ class Postgres extends Base
      */
     public function getSchemaVersion()
     {
-        $this->pdo->exec("CREATE TABLE IF NOT EXISTS ".$this->schemaTable." (version INTEGER DEFAULT 0)");
+        $this->getConnection()->exec("CREATE TABLE IF NOT EXISTS ".$this->schemaTable." (version INTEGER DEFAULT 0)");
 
-        $rq = $this->pdo->prepare('SELECT "version" FROM "'.$this->schemaTable.'"');
+        $rq = $this->getConnection()->prepare('SELECT "version" FROM "'.$this->schemaTable.'"');
         $rq->execute();
         $result = $rq->fetchColumn();
 
@@ -169,7 +169,7 @@ class Postgres extends Base
             return (int) $result;
         }
         else {
-            $this->pdo->exec('INSERT INTO '.$this->schemaTable.' VALUES(0)');
+            $this->getConnection()->exec('INSERT INTO '.$this->schemaTable.' VALUES(0)');
         }
 
         return 0;
@@ -183,7 +183,7 @@ class Postgres extends Base
      */
     public function setSchemaVersion($version)
     {
-        $rq = $this->pdo->prepare('UPDATE '.$this->schemaTable.' SET version=?');
+        $rq = $this->getConnection()->prepare('UPDATE '.$this->schemaTable.' SET version=?');
         $rq->execute(array($version));
     }
 

--- a/lib/PicoDb/Driver/Postgres.php
+++ b/lib/PicoDb/Driver/Postgres.php
@@ -134,18 +134,17 @@ class Postgres extends Base
      * Get last inserted id
      *
      * @access public
-     * @return integer
      */
-    public function getLastId()
+    public function getLastId(): string|false
     {
         try {
             $rq = $this->getConnection()->prepare('SELECT LASTVAL()');
             $rq->execute();
 
-            return $rq->fetchColumn();
+            return (string) $rq->fetchColumn();
         }
         catch (PDOException $e) {
-            return 0;
+            return false;
         }
     }
 

--- a/lib/PicoDb/Driver/Postgres.php
+++ b/lib/PicoDb/Driver/Postgres.php
@@ -17,19 +17,17 @@ class Postgres extends Base
      * List of required settings options
      *
      * @access protected
-     * @var array
      */
-    protected $requiredAttributes = array(
+    protected array $requiredAttributes = [
         'database',
-    );
+    ];
 
     /**
      * Table to store the schema version
      *
      * @access private
-     * @var array
      */
-    private $schemaTable = 'schema_version';
+    private string $schemaTable = 'schema_version';
 
     /**
      * Create a new PDO connection

--- a/lib/PicoDb/Driver/Sqlite.php
+++ b/lib/PicoDb/Driver/Sqlite.php
@@ -17,9 +17,8 @@ class Sqlite extends Base
      * List of required settings options
      *
      * @access protected
-     * @var array
      */
-    protected $requiredAttributes = array('filename');
+    protected array $requiredAttributes = ['filename'];
 
     /**
      * Create a new PDO connection

--- a/lib/PicoDb/Driver/Sqlite.php
+++ b/lib/PicoDb/Driver/Sqlite.php
@@ -102,9 +102,8 @@ class Sqlite extends Base
      * Get last inserted id
      *
      * @access public
-     * @return integer
      */
-    public function getLastId()
+    public function getLastId(): string|false
     {
         return $this->getConnection()->lastInsertId();
     }

--- a/lib/PicoDb/Driver/Sqlite.php
+++ b/lib/PicoDb/Driver/Sqlite.php
@@ -35,7 +35,7 @@ class Sqlite extends Base
             $options[PDO::ATTR_TIMEOUT] = $settings['timeout'];
         }
 
-        $this->pdo = new PDO('sqlite:'.$settings['filename'], null, null, $options);
+        $this->setConnection(new PDO('sqlite:'.$settings['filename'], null, null, $options));
         $this->enableForeignKeys();
     }
 
@@ -46,7 +46,7 @@ class Sqlite extends Base
      */
     public function enableForeignKeys()
     {
-        $this->pdo->exec('PRAGMA foreign_keys = ON');
+        $this->getConnection()->exec('PRAGMA foreign_keys = ON');
     }
 
     /**
@@ -56,7 +56,7 @@ class Sqlite extends Base
      */
     public function disableForeignKeys()
     {
-        $this->pdo->exec('PRAGMA foreign_keys = OFF');
+        $this->getConnection()->exec('PRAGMA foreign_keys = OFF');
     }
 
     /**
@@ -107,7 +107,7 @@ class Sqlite extends Base
      */
     public function getLastId()
     {
-        return $this->pdo->lastInsertId();
+        return $this->getConnection()->lastInsertId();
     }
 
     /**
@@ -118,7 +118,7 @@ class Sqlite extends Base
      */
     public function getSchemaVersion()
     {
-        $rq = $this->pdo->prepare('PRAGMA user_version');
+        $rq = $this->getConnection()->prepare('PRAGMA user_version');
         $rq->execute();
 
         return (int) $rq->fetchColumn();
@@ -132,7 +132,7 @@ class Sqlite extends Base
      */
     public function setSchemaVersion($version)
     {
-        $this->pdo->exec('PRAGMA user_version='.$version);
+        $this->getConnection()->exec('PRAGMA user_version='.$version);
     }
 
     /**
@@ -148,7 +148,7 @@ class Sqlite extends Base
     public function upsert($table, $keyColumn, $valueColumn, array $dictionary)
     {
         try {
-            $this->pdo->beginTransaction();
+            $this->getConnection()->beginTransaction();
 
             foreach ($dictionary as $key => $value) {
 
@@ -159,16 +159,16 @@ class Sqlite extends Base
                     $this->escape($valueColumn)
                 );
 
-                $rq = $this->pdo->prepare($sql);
+                $rq = $this->getConnection()->prepare($sql);
                 $rq->execute(array($key, $value));
             }
 
-            $this->pdo->commit();
+            $this->getConnection()->commit();
 
             return true;
         }
         catch (PDOException $e) {
-            $this->pdo->rollBack();
+            $this->getConnection()->rollBack();
             return false;
         }
     }

--- a/tests/PicoDb/StatementHandlerTest.php
+++ b/tests/PicoDb/StatementHandlerTest.php
@@ -105,4 +105,36 @@ class StatementHandlerTest extends TestCase
             var_export($logMessages, true)
         );
     }
+
+    public function testMoreValuesThanPlaceholders()
+    {
+        $statementHandler = new class($this->db) extends StatementHandler {
+            public function testBeforeExecute(array $props)
+            {
+                foreach ($props as $key => $value) {
+                    $this->{$key} = $value;
+                }
+                $this->beforeExecute();
+            }
+        };
+
+        // SQL has 1 placeholder but 3 values — extra values should be ignored gracefully
+        $statementHandler->testBeforeExecute([
+            'logQueries' => true,
+            'logQueryValues' => true,
+            'useNamedParams' => false,
+            'sql' => "SELECT * FROM `some_table` WHERE `id` = ?",
+            'lobParams' => ['value1', 'extra_value2', 'extra_value3'],
+            'positionalParams' => [],
+            'namedParams' => [],
+        ]);
+
+        $logMessages = $this->db->getLogMessages();
+        $lastMessage = end($logMessages);
+        self::assertEquals(
+            "SELECT * FROM `some_table` WHERE `id` = 'value1'",
+            $lastMessage,
+            var_export($logMessages, true)
+        );
+    }
 }

--- a/tests/SqliteDriverTest.php
+++ b/tests/SqliteDriverTest.php
@@ -14,6 +14,23 @@ class SqliteDriverTest extends \PHPUnit\Framework\TestCase
         $this->driver = new Sqlite(array('filename' => ':memory:'));
     }
 
+    public function testGetConnectionReturnsPdo()
+    {
+        $this->assertInstanceOf(PDO::class, $this->driver->getConnection());
+    }
+
+    public function testGetConnectionThrowsWhenNotInitialized()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The database connection is not established.');
+
+        $reflection = new ReflectionProperty(PicoDb\Driver\Base::class, 'pdo');
+        $reflection->setAccessible(true);
+        $reflection->setValue($this->driver, null);
+
+        $this->driver->getConnection();
+    }
+
     public function testMissingRequiredParameter()
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
This is the first PR in an attempt to slowly bring types into this library. There's some key areas that need to be tackled manually first like this before I can bring in automated tooling like Rector.

I typed `$pdo` as `?PDO`, made it private and updated all usages to access it via `getConnection()`. 
I've added a `setConnection()` method to allow children to set it.
I've opted to make `getConnection()` throw an exception if the connection isn't established.
This was the least intrusive change as this maintains the existing contract all the code was working under, that it always returns `PDO`.

Other small fixes:
- Typed a handful of other private class properties on the drivers (`$requiredAttributes` and `$schemaTable`)
- Fixed a type issue in `getSqlFromPreparedStatement` that would occur if there were more items in `$values` than '?' in `$sql` (Unlikely to actually happen, but Psalm picked it up)
- Added Psalm as a composer command.
