### PR TITLE
Add methods to wrap closure in conditions rather than use beginAnd, closeAnd, etc 

### DIFF
--- a/lib/PicoDb/Builder/BaseConditionBuilder.php
+++ b/lib/PicoDb/Builder/BaseConditionBuilder.php
@@ -177,7 +177,9 @@ class BaseConditionBuilder
     }
 
     /**
-     * Start OR condition
+     * Start XOR condition
+     *
+     * Only supported by MySQL and MSSQL. Not supported by SQLite or PostgreSQL.
      *
      * @access public
      */

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -931,7 +931,7 @@ class Table
      *
      * @param Closure(static) $callback
      */
-    public function withAnd(Closure $callback): static
+    public function and(Closure $callback): static
     {
         $this->beginAnd();
         $callback($this);
@@ -944,7 +944,7 @@ class Table
      *
      * @param Closure(static) $callback
      */
-    public function withOr(Closure $callback): static
+    public function or(Closure $callback): static
     {
         $this->beginOr();
         $callback($this);
@@ -955,12 +955,12 @@ class Table
     /**
      * Wrap conditions with NOT logic using a callback
      *
-     * Unlike withAnd/withOr/withXor, NOT always joins multiple conditions with AND internally.
-     * To negate an OR group, nest withOr inside: withNot(fn($q) => $q->withOr(...))
+     * Unlike and/or/xor, NOT always joins multiple conditions with AND internally.
+     * To negate an OR group, nest or inside: not(fn($q) => $q->or(...))
      *
      * @param Closure(static) $callback
      */
-    public function withNot(Closure $callback): static
+    public function not(Closure $callback): static
     {
         $this->beginNot();
         $callback($this);
@@ -975,7 +975,7 @@ class Table
      *
      * @param Closure(static) $callback
      */
-    public function withXor(Closure $callback): static
+    public function xor(Closure $callback): static
     {
         $this->beginXor();
         $callback($this);

--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -927,6 +927,63 @@ class Table
     }
 
     /**
+     * Wrap conditions with AND logic using a callback
+     *
+     * @param Closure(static) $callback
+     */
+    public function withAnd(Closure $callback): static
+    {
+        $this->beginAnd();
+        $callback($this);
+        $this->closeAnd();
+        return $this;
+    }
+
+    /**
+     * Wrap conditions with OR logic using a callback
+     *
+     * @param Closure(static) $callback
+     */
+    public function withOr(Closure $callback): static
+    {
+        $this->beginOr();
+        $callback($this);
+        $this->closeOr();
+        return $this;
+    }
+
+    /**
+     * Wrap conditions with NOT logic using a callback
+     *
+     * Unlike withAnd/withOr/withXor, NOT always joins multiple conditions with AND internally.
+     * To negate an OR group, nest withOr inside: withNot(fn($q) => $q->withOr(...))
+     *
+     * @param Closure(static) $callback
+     */
+    public function withNot(Closure $callback): static
+    {
+        $this->beginNot();
+        $callback($this);
+        $this->closeNot();
+        return $this;
+    }
+
+    /**
+     * Wrap conditions with XOR logic using a callback
+     *
+     * Only supported by MySQL and MSSQL. Not supported by SQLite or PostgreSQL.
+     *
+     * @param Closure(static) $callback
+     */
+    public function withXor(Closure $callback): static
+    {
+        $this->beginXor();
+        $callback($this);
+        $this->closeXor();
+        return $this;
+    }
+
+    /**
      * Magic method for sql conditions
      *
      * @access public

--- a/tests/MssqlTableTest.php
+++ b/tests/MssqlTableTest.php
@@ -366,6 +366,14 @@ class MssqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 
+    public function testWithXor()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM [test]   WHERE [a] IS NOT NULL AND ([b] = ? XOR [c] >= ?)', $table->notNull('a')->withXor(fn($q) => $q->eq('b', 2)->gte('c', 5))->buildSelectQuery());
+        $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
+    }
+
     public function testHavingSubquery()
     {
         $table = $this->db->table('test')->notNull('a')->beginOr()->eq('b', 2)->gte('c', 5)->closeOr();

--- a/tests/MssqlTableTest.php
+++ b/tests/MssqlTableTest.php
@@ -366,11 +366,11 @@ class MssqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 
-    public function testWithXor()
+    public function testXor()
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM [test]   WHERE [a] IS NOT NULL AND ([b] = ? XOR [c] >= ?)', $table->notNull('a')->withXor(fn($q) => $q->eq('b', 2)->gte('c', 5))->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM [test]   WHERE [a] IS NOT NULL AND ([b] = ? XOR [c] >= ?)', $table->notNull('a')->xor(fn($q) => $q->eq('b', 2)->gte('c', 5))->buildSelectQuery());
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -365,6 +365,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 
+    public function testWithXor()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` IS NOT NULL AND (`b` = ? XOR `c` >= ?)', $table->notNull('a')->withXor(fn($q) => $q->eq('b', 2)->gte('c', 5))->buildSelectQuery());
+        $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
+    }
+
     public function testHavingSubquery()
     {
         $table = $this->db->table('test')->notNull('a')->beginOr()->eq('b', 2)->gte('c', 5)->closeOr();

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -365,11 +365,11 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 
-    public function testWithXor()
+    public function testXor()
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM `test`   WHERE `a` IS NOT NULL AND (`b` = ? XOR `c` >= ?)', $table->notNull('a')->withXor(fn($q) => $q->eq('b', 2)->gte('c', 5))->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM `test`   WHERE `a` IS NOT NULL AND (`b` = ? XOR `c` >= ?)', $table->notNull('a')->xor(fn($q) => $q->eq('b', 2)->gte('c', 5))->buildSelectQuery());
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -401,39 +401,39 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 
-    public function testWithAnd()
+    public function testAnd()
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM "test"   WHERE ("a" = ? AND "b" = ?)', $table->withAnd(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE ("a" = ? AND "b" = ?)', $table->and(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
         $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
-    public function testWithOr()
+    public function testOr()
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM "test"   WHERE ("a" = ? OR "b" = ?)', $table->withOr(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE ("a" = ? OR "b" = ?)', $table->or(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
         $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
-    public function testWithNot()
+    public function testNot()
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->withNot(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->not(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
         $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
     }
 
-    public function testWithNotSingleCondition()
+    public function testNotSingleCondition()
     {
         $table = $this->db->table('test');
 
-        $this->assertEquals('SELECT * FROM "test"   WHERE NOT "a" = ?', $table->withNot(fn($q) => $q->eq('a', 1))->buildSelectQuery());
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT "a" = ?', $table->not(fn($q) => $q->eq('a', 1))->buildSelectQuery());
         $this->assertEquals(array(1), $table->getConditionBuilder()->getValues());
     }
 
-    public function testWithOrNested()
+    public function testOrNested()
     {
         $table = $this->db->table('test');
 
@@ -441,9 +441,9 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
             'SELECT * FROM "test"   WHERE "a" IS NOT NULL AND ("b" = ? OR ("c" = ? AND "d" >= ?))',
             $table
                 ->notNull('a')
-                ->withOr(fn($q) => $q
+                ->or(fn($q) => $q
                     ->eq('b', 2)
-                    ->withAnd(fn($q) => $q->eq('c', 3)->gte('d', 5))
+                    ->and(fn($q) => $q->eq('c', 3)->gte('d', 5))
                 )
                 ->buildSelectQuery()
         );

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -401,6 +401,55 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(2, 5), $table->getConditionBuilder()->getValues());
     }
 
+    public function testWithAnd()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE ("a" = ? AND "b" = ?)', $table->withAnd(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testWithOr()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE ("a" = ? OR "b" = ?)', $table->withOr(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testWithNot()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT ("a" = ? AND "b" = ?)', $table->withNot(fn($q) => $q->eq('a', 1)->eq('b', 2))->buildSelectQuery());
+        $this->assertEquals(array(1, 2), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testWithNotSingleCondition()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals('SELECT * FROM "test"   WHERE NOT "a" = ?', $table->withNot(fn($q) => $q->eq('a', 1))->buildSelectQuery());
+        $this->assertEquals(array(1), $table->getConditionBuilder()->getValues());
+    }
+
+    public function testWithOrNested()
+    {
+        $table = $this->db->table('test');
+
+        $this->assertEquals(
+            'SELECT * FROM "test"   WHERE "a" IS NOT NULL AND ("b" = ? OR ("c" = ? AND "d" >= ?))',
+            $table
+                ->notNull('a')
+                ->withOr(fn($q) => $q
+                    ->eq('b', 2)
+                    ->withAnd(fn($q) => $q->eq('c', 3)->gte('d', 5))
+                )
+                ->buildSelectQuery()
+        );
+        $this->assertEquals(array(2, 3, 5), $table->getConditionBuilder()->getValues());
+    }
+
     public function testHavingSubquery()
     {
         $table = $this->db->table('test')->notNull('a')->beginOr()->eq('b', 2)->gte('c', 5)->closeOr();


### PR DESCRIPTION
Thought this would provide a slightly nicer way of declaring and/or conditions rather than using begin/close directly.