### PR TITLE
Escape column input in table sum

### DIFF
--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -469,7 +469,7 @@ class Table
     {
         $sql = sprintf(
             'SELECT SUM(%s) FROM %s %s %s %s %s %s %s',
-            $column,
+            $this->db->escapeIdentifier($column),
             $this->db->escapeIdentifier($this->name),
             implode(' ', $this->joins),
             $this->conditionBuilder->build(),

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -445,6 +445,14 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(7, $this->db->table('foobar')->sum('a'));
     }
 
+    public function testSumWithReservedWordColumn()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE foobar (`order` INTEGER)'));
+        $this->assertTrue($this->db->table('foobar')->insert(array('order' => 3)));
+        $this->assertTrue($this->db->table('foobar')->insert(array('order' => 4)));
+        $this->assertEquals(7, $this->db->table('foobar')->sum('order'));
+    }
+
     public function testSumSubqueryHaving()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE foobar(foo INTEGER, status INTEGER DEFAULT 0)'));


### PR DESCRIPTION
From a claude security scan it highlighted that `sum($column)` in `lib/PicoDb/Table.php` wasn't using `$this->db->escapeIdentifier()` for `$column` input parameter.
Everywhere else there is a `$column` input parameter is used is escaped.
From commit logs it looks like it existed before and was removed in commit `daf9b7404cad3bf559f955193c424580c7799d30` - "Add notLike, between and not between. #15". 
This seems like it was unintentional regression.
Unit test added to test fix.
Security update and potential breaking change.