### PR TITLE
Use pdo quote for explain string replacment

### DIFF
--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -253,7 +253,8 @@ abstract class Base
             if ($pos === false) {
                 break;
             }
-            $sql = substr_replace($sql, $this->getConnection()->quote($value), $pos, 1);
+            $quoted = is_null($value) ? 'NULL' : $this->getConnection()->quote($value);
+            $sql = substr_replace($sql, $quoted, $pos, 1);
         }
 
         return $sql;

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -253,7 +253,7 @@ abstract class Base
             if ($pos === false) {
                 break;
             }
-            $sql = substr_replace($sql, "'$value'", $pos, 1);
+            $sql = substr_replace($sql, $this->getConnection()->quote($value), $pos, 1);
         }
 
         return $sql;


### PR DESCRIPTION
A claude security scan that highlighted that single quotation marks in $value break out of string literals. A legitimate use case is `O'Brien`. 

For this solution, using`$this->getConnection()->quote($value)` as it will handle the correct escaping per db.

This issue is that it will change the behaviour for null values passed in. `quote(null)`

Before `"'$value'"` with `$value = null` would result in `''` (an empty single quotes string). 

With `quote(null)` it will return the string `'NULL'` (NULL surrounded by single quotes) on Postgres and on the rest of the drives it will return `''`.
To facilitate null mapping instead, a null guard is being used.

Added unit tests testing fix.

This is breaking change.
