### PR TITLE
Use pdo quote for explain string replacment

### DIFF
--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -253,7 +253,7 @@ abstract class Base
             if ($pos === false) {
                 break;
             }
-            $quoted = is_null($value) ? 'NULL' : $this->getConnection()->quote($value);
+            $quoted = is_null($value) ? "''" : $this->getConnection()->quote($value);
             $sql = substr_replace($sql, $quoted, $pos, 1);
         }
 

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -253,7 +253,8 @@ abstract class Base
             if ($pos === false) {
                 break;
             }
-            $sql = substr_replace($sql, $this->getConnection()->quote($value), $pos, 1);
+            $quoted = is_null($value) ? 'NULL' : $this->getConnection()->quote($value);
+            $sql = substr_replace($sql, $quoted, $pos, 1);
         }
 
         return $sql;

--- a/lib/PicoDb/Driver/Base.php
+++ b/lib/PicoDb/Driver/Base.php
@@ -253,7 +253,7 @@ abstract class Base
             if ($pos === false) {
                 break;
             }
-            $sql = substr_replace($sql, "'$value'", $pos, 1);
+            $sql = substr_replace($sql, $this->getConnection()->quote($value), $pos, 1);
         }
 
         return $sql;

--- a/tests/MysqlDriverTest.php
+++ b/tests/MysqlDriverTest.php
@@ -67,4 +67,11 @@ class MysqlDriverTest extends \PHPUnit\Framework\TestCase
 //    {
 //        $this->assertStringStartsWith('5.', $this->driver->getDatabaseVersion());
 //    }
+
+    public function testExplainWithSingleQuoteValue()
+    {
+        $this->driver->getConnection()->exec('CREATE TABLE foobar (name VARCHAR(100))');
+        $result = $this->driver->explain('SELECT * FROM `foobar` WHERE `name` = ?', ["O'Brien"]);
+        $this->assertIsArray($result);
+    }
 }

--- a/tests/PostgresDriverTest.php
+++ b/tests/PostgresDriverTest.php
@@ -73,4 +73,11 @@ class PostgresDriverTest extends \PHPUnit\Framework\TestCase
 //    {
 //        $this->assertStringStartsWith('11.', $this->driver->getDatabaseVersion());
 //    }
+
+    public function testExplainWithSingleQuoteValue()
+    {
+        $this->driver->getConnection()->exec('CREATE TABLE foobar (name TEXT)');
+        $result = $this->driver->explain('SELECT * FROM "foobar" WHERE "name" = ?', ["O'Brien"]);
+        $this->assertIsArray($result);
+    }
 }

--- a/tests/SqliteDriverTest.php
+++ b/tests/SqliteDriverTest.php
@@ -81,4 +81,11 @@ class SqliteDriverTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertStringStartsWith('3.', $this->driver->getDatabaseVersion());
     }
+
+    public function testExplainWithSingleQuoteValue()
+    {
+        $this->driver->getConnection()->exec('CREATE TABLE foobar (name TEXT)');
+        $result = $this->driver->explain('SELECT * FROM "foobar" WHERE "name" = ?', ["O'Brien"]);
+        $this->assertIsArray($result);
+    }
 }


### PR DESCRIPTION
A claude security scan that highlighted that single quotation marks in $value break out of string literals. A legitimate use case is `O'Brien`. 

For this solution, using`$this->getConnection()->quote($value)` as it will handle the correct escaping per db.

The issue is `quote(null)` returns different values between drivers. Postres returns `'NULL'` and the rest returns `''`.
Current behaviour for `$value = null;` is `''` empty single quoted string.
To this end, a null guard is included to preserve old functionality for null values.

Unit test added to test fix.

This is a breaking change.