### PR TITLE
Accept null conditions on left and inner joins

### DIFF
--- a/lib/PicoDb/Table.php
+++ b/lib/PicoDb/Table.php
@@ -573,6 +573,8 @@ class Table
             if (is_array($value)) {
                 $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' IN (' . implode(',', array_fill(0, count($value), '?')) . ')';
                 $this->joinValues = array_merge($this->joinValues, $value);
+            } elseif (is_null($value)) {
+                $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' IS NULL';
             } else {
                 $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' = ?';
                 $this->joinValues[] = $value;
@@ -610,6 +612,8 @@ class Table
             if (is_array($value)) {
                 $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' IN (' . implode(',', array_fill(0, count($value), '?')) . ')';
                 $this->joinValues = array_merge($this->joinValues, $value);
+            } elseif (is_null($value)) {
+                $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' IS NULL';
             } else {
                 $where .= ' AND ' . $this->db->escapeIdentifier($alias1) . '.' . $this->db->escapeIdentifier($column) . ' = ?';
                 $this->joinValues[] = $value;

--- a/tests/MssqlTableTest.php
+++ b/tests/MssqlTableTest.php
@@ -544,6 +544,75 @@ class MssqlTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testLeftJoinNullCondition()
+    {
+        $query = $this->db->table('test2')->columns('a', 'b')->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null]);
+
+        $this->assertEquals(
+            'SELECT [a], [b] FROM [test2] LEFT JOIN [test1] AS [t1] ON [t1].[foreign_key]=[test2].[id] AND [t1].[a] IS NULL',
+            $query->buildSelectQuery()
+        );
+        $this->assertEquals([], $query->getValues());
+
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => null, 'foreign_key' => 42)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => null, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null])->findOne()
+        );
+    }
+
+    public function testInnerJoinConditions()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER NOT NULL, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
+        );
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => [18, 19]])->findOne()
+        );
+
+        $this->assertNull(
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
+        );
+    }
+
+    public function testInnerJoinNullCondition()
+    {
+        $query = $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null]);
+
+        $this->assertEquals(
+            'SELECT [a], [b] FROM [test2] JOIN [test1] AS [t1] ON [t1].[foreign_key]=[test2].[id] AND [t1].[a] IS NULL',
+            $query->buildSelectQuery()
+        );
+        $this->assertEquals([], $query->getValues());
+
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => null, 'foreign_key' => 42)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => null, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null])->findOne()
+        );
+    }
+
     public function testJoinSubquery()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));

--- a/tests/MysqlTableTest.php
+++ b/tests/MysqlTableTest.php
@@ -550,6 +550,75 @@ class MysqlTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testLeftJoinNullCondition()
+    {
+        $query = $this->db->table('test2')->columns('a', 'b')->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null]);
+
+        $this->assertEquals(
+            'SELECT `a`, `b` FROM `test2` LEFT JOIN `test1` AS `t1` ON `t1`.`foreign_key`=`test2`.`id` AND `t1`.`a` IS NULL',
+            $query->buildSelectQuery()
+        );
+        $this->assertEquals([], $query->getValues());
+
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => null, 'foreign_key' => 42)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => null, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null])->findOne()
+        );
+    }
+
+    public function testInnerJoinConditions()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER NOT NULL, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
+        );
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => [18, 19]])->findOne()
+        );
+
+        $this->assertNull(
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
+        );
+    }
+
+    public function testInnerJoinNullCondition()
+    {
+        $query = $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null]);
+
+        $this->assertEquals(
+            'SELECT `a`, `b` FROM `test2` JOIN `test1` AS `t1` ON `t1`.`foreign_key`=`test2`.`id` AND `t1`.`a` IS NULL',
+            $query->buildSelectQuery()
+        );
+        $this->assertEquals([], $query->getValues());
+
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => null, 'foreign_key' => 42)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => null, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null])->findOne()
+        );
+    }
+
     public function testJoinSubquery()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));

--- a/tests/PostgresTableTest.php
+++ b/tests/PostgresTableTest.php
@@ -523,6 +523,75 @@ class PostgresTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testLeftJoinNullCondition()
+    {
+        $query = $this->db->table('test2')->columns('a', 'b')->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null]);
+
+        $this->assertEquals(
+            'SELECT "a", "b" FROM "test2" LEFT JOIN "test1" AS "t1" ON "t1"."foreign_key"="test2"."id" AND "t1"."a" IS NULL',
+            $query->buildSelectQuery()
+        );
+        $this->assertEquals([], $query->getValues());
+
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => null, 'foreign_key' => 42)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => null, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null])->findOne()
+        );
+    }
+
+    public function testInnerJoinConditions()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER NOT NULL, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
+        );
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => [18, 19]])->findOne()
+        );
+
+        $this->assertNull(
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
+        );
+    }
+
+    public function testInnerJoinNullCondition()
+    {
+        $query = $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null]);
+
+        $this->assertEquals(
+            'SELECT "a", "b" FROM "test2" JOIN "test1" AS "t1" ON "t1"."foreign_key"="test2"."id" AND "t1"."a" IS NULL',
+            $query->buildSelectQuery()
+        );
+        $this->assertEquals([], $query->getValues());
+
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => null, 'foreign_key' => 42)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => null, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null])->findOne()
+        );
+    }
+
     public function testJoinSubquery()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));

--- a/tests/SqliteTableTest.php
+++ b/tests/SqliteTableTest.php
@@ -660,6 +660,75 @@ class SqliteTableTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testLeftJoinNullCondition()
+    {
+        $query = $this->db->table('test2')->columns('a', 'b')->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null]);
+
+        $this->assertEquals(
+            'SELECT "a", "b" FROM "test2" LEFT JOIN "test1" AS "t1" ON "t1"."foreign_key"="test2"."id" AND "t1"."a" IS NULL',
+            $query->buildSelectQuery()
+        );
+        $this->assertEquals([], $query->getValues());
+
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => null, 'foreign_key' => 42)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => null, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->left('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null])->findOne()
+        );
+    }
+
+    public function testInnerJoinConditions()
+    {
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER NOT NULL, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 18])->findOne()
+        );
+
+        $this->assertEquals(
+            array('a' => 18, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => [18, 19]])->findOne()
+        );
+
+        $this->assertNull(
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => 19])->findOne()
+        );
+    }
+
+    public function testInnerJoinNullCondition()
+    {
+        $query = $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null]);
+
+        $this->assertEquals(
+            'SELECT "a", "b" FROM "test2" JOIN "test1" AS "t1" ON "t1"."foreign_key"="test2"."id" AND "t1"."a" IS NULL',
+            $query->buildSelectQuery()
+        );
+        $this->assertEquals([], $query->getValues());
+
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (a INTEGER, foreign_key INTEGER NOT NULL)'));
+        $this->assertNotFalse($this->db->execute('CREATE TABLE test2 (id INTEGER NOT NULL, b INTEGER NOT NULL)'));
+
+        $this->assertTrue($this->db->table('test2')->insert(array('id' => 42, 'b' => 2)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => null, 'foreign_key' => 42)));
+        $this->assertTrue($this->db->table('test1')->insert(array('a' => 18, 'foreign_key' => 42)));
+
+        $this->assertEquals(
+            array('a' => null, 'b' => 2),
+            $this->db->table('test2')->columns('a', 'b')->inner('test1', 't1', 'foreign_key', 'test2', 'id', ['a' => null])->findOne()
+        );
+    }
+
     public function testJoinSubquery()
     {
         $this->assertNotFalse($this->db->execute('CREATE TABLE test1 (id INTEGER NOT NULL, a INTEGER NOT NULL)'));


### PR DESCRIPTION
Currently it tries to do "where column = null" which doesn't work :sweat_smile: 

This fixes that and allows null conditions on joins.